### PR TITLE
Potential fix for code scanning alert no. 3: Unnecessary use of `cat` process

### DIFF
--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 
 const program = new Command();
@@ -55,7 +56,7 @@ program
       };
 
       try {
-        const existingTsConfig = JSON.parse(execSync('cat tsconfig.json', { encoding: 'utf-8' }));
+        const existingTsConfig = JSON.parse(readFileSync('tsconfig.json', 'utf-8'));
         tsConfig = {
           ...existingTsConfig,
           compilerOptions: {


### PR DESCRIPTION
Potential fix for [https://github.com/haydenbleasel/ultracite/security/code-scanning/3](https://github.com/haydenbleasel/ultracite/security/code-scanning/3)

To fix the problem, we need to replace the use of `execSync('cat tsconfig.json', { encoding: 'utf-8' })` with `fs.readFileSync('tsconfig.json', 'utf-8')`. This change will make the code more efficient, portable, and secure.

1. Import the `fs` module at the beginning of the file.
2. Replace the `execSync` call with `fs.readFileSync` to read the contents of `tsconfig.json`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
