### PR TITLE
fix: replace 'npx biome' with 'npx @biomejs/biome'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,10 +132,10 @@ export const integration = {
 ### Development
 ```bash
 # Run Biome formatter on this project
-npx biome check --write ./
+npx @biomejs/biome check --write ./
 
 # Run Biome linter without fixes
-npx biome check ./
+npx @biomejs/biome check ./
 
 # Test the CLI locally
 node ./dist/index.js init
@@ -174,7 +174,7 @@ The `docs/` directory contains a Next.js website:
 3. Users will get updated rules on next `ultracite init`
 
 ### Debugging Issues
-1. Check if it's a Biome issue first: `npx biome check`
+1. Check if it's a Biome issue first: `npx @biomejs/biome check`
 2. Enable verbose output in the scripts
 3. Check test files for expected behavior
 

--- a/__tests__/format.test.ts
+++ b/__tests__/format.test.ts
@@ -15,7 +15,7 @@ describe('format command', () => {
   it('should run biome check with --write flag for all files when no files specified', () => {
     format([]);
 
-    expect(mockExecSync).toHaveBeenCalledWith('npx biome check --write ./', {
+    expect(mockExecSync).toHaveBeenCalledWith('npx @biomejs/biome check --write ./', {
       stdio: 'inherit',
     });
   });
@@ -25,7 +25,7 @@ describe('format command', () => {
     format(files);
 
     expect(mockExecSync).toHaveBeenCalledWith(
-      'npx biome check --write src/index.ts src/utils.ts',
+      'npx @biomejs/biome check --write src/index.ts src/utils.ts',
       { stdio: 'inherit' }
     );
   });
@@ -35,7 +35,7 @@ describe('format command', () => {
     format(files);
 
     expect(mockExecSync).toHaveBeenCalledWith(
-      'npx biome check --write src/index.ts',
+      'npx @biomejs/biome check --write src/index.ts',
       { stdio: 'inherit' }
     );
   });

--- a/__tests__/lint.test.ts
+++ b/__tests__/lint.test.ts
@@ -15,7 +15,7 @@ describe('lint command', () => {
   it('should run biome check without --write flag for all files when no files specified', () => {
     lint([]);
 
-    expect(mockExecSync).toHaveBeenCalledWith('npx biome check ./', {
+    expect(mockExecSync).toHaveBeenCalledWith('npx @biomejs/biome check ./', {
       stdio: 'inherit',
     });
   });
@@ -25,7 +25,7 @@ describe('lint command', () => {
     lint(files);
 
     expect(mockExecSync).toHaveBeenCalledWith(
-      'npx biome check src/index.ts src/utils.ts',
+      'npx @biomejs/biome check src/index.ts src/utils.ts',
       { stdio: 'inherit' }
     );
   });
@@ -34,7 +34,7 @@ describe('lint command', () => {
     const files = ['src/index.ts'];
     lint(files);
 
-    expect(mockExecSync).toHaveBeenCalledWith('npx biome check src/index.ts', {
+    expect(mockExecSync).toHaveBeenCalledWith('npx @biomejs/biome check src/index.ts', {
       stdio: 'inherit',
     });
   });

--- a/docs/content/contributing.mdx
+++ b/docs/content/contributing.mdx
@@ -17,7 +17,7 @@ If you want to modify Ultracite or test changes:
 2. Run pnpm install (the project uses pnpm for managing dependencies and a lockfile, as indicated in the repo).
 3. The config is in `biome.jsonc` and related files. The CLI command (like `ultracite init`) likely has a script in the repo – check the `package.json` bin field or the `scripts/` directory for implementation.
 4. You can link your local Ultracite into a test project by using npm/yarn/pnpm link or npm pack to create a tarball and install it. This way, you can try your version of Ultracite on a sample project to see the effect of changes.
-5. If you adjust rules in the config, test them by running npx biome lint or similar in the context of that config.
+5. If you adjust rules in the config, test them by running npx @biomejs/biome lint or similar in the context of that config.
 
 ## Project structure
 

--- a/scripts/format.ts
+++ b/scripts/format.ts
@@ -9,7 +9,7 @@ export const format = (files: string[], options: FormatOptions) => {
   try {
     const target = files.length > 0 ? files.join(' ') : './';
     const unsafeFlag = options.unsafe ? '--unsafe' : '';
-    execSync(`npx biome check --write ${unsafeFlag} ${target}`, { stdio: 'inherit' });
+    execSync(`npx @biomejs/biome check --write ${unsafeFlag} ${target}`, { stdio: 'inherit' });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
 

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 export const lint = (files: string[]) => {
   try {
     const target = files.length > 0 ? files.join(' ') : './';
-    execSync(`npx biome check ${target}`, { stdio: 'inherit' });
+    execSync(`npx @biomejs/biome check ${target}`, { stdio: 'inherit' });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     // biome-ignore lint/suspicious/noConsole: "We want to log the error to the console"


### PR DESCRIPTION
## Description

Replaces all occurrences of `npx biome` with `npx @biomejs/biome`, as [`biome`](https://www.npmjs.com/package/biome) is an unrelated package and **not the correct CLI**.

This aligns the CLI usage in scripts, tests, and documentation with the official Biome commands as documented here:  
https://biomejs.dev/guides/getting-started/

![image](https://github.com/user-attachments/assets/31d5eb06-dc73-4862-b37b-65abf7f9ecde)

## Additional Notes

It's my first PR.
I just searched and replaced all the occurrences of `npx biome` with `npx @biomejs/biome`.
