### PR TITLE
Zed Settings

### DIFF
--- a/__tests__/zed-copilot.test.ts
+++ b/__tests__/zed-copilot.test.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { exists } from '../scripts/utils';
-import { zed } from '../scripts/zed';
+import { zedCopilot } from '../scripts/zed-copilot';
 
 vi.mock('node:fs/promises');
 vi.mock('../scripts/utils', () => ({
@@ -11,7 +11,7 @@ vi.mock('../docs/lib/rules', () => ({
   rulesFile: 'mock rules content',
 }));
 
-describe('zed configuration', () => {
+describe('zed rules configuration', () => {
   const mockReadFile = vi.mocked(readFile);
   const mockWriteFile = vi.mocked(writeFile);
   const mockExists = vi.mocked(exists);
@@ -25,7 +25,7 @@ describe('zed configuration', () => {
     it('should return true when .rules exists', async () => {
       mockExists.mockResolvedValue(true);
 
-      const result = await zed.exists();
+      const result = await zedCopilot.exists();
 
       expect(result).toBe(true);
       expect(mockExists).toHaveBeenCalledWith('./.rules');
@@ -34,7 +34,7 @@ describe('zed configuration', () => {
     it('should return false when .rules does not exist', async () => {
       mockExists.mockResolvedValue(false);
 
-      const result = await zed.exists();
+      const result = await zedCopilot.exists();
 
       expect(result).toBe(false);
       expect(mockExists).toHaveBeenCalledWith('./.rules');
@@ -43,7 +43,7 @@ describe('zed configuration', () => {
 
   describe('create', () => {
     it('should create .rules with rules content', async () => {
-      await zed.create();
+      await zedCopilot.create();
 
       expect(mockWriteFile).toHaveBeenCalledWith(
         './.rules',
@@ -56,7 +56,7 @@ describe('zed configuration', () => {
     it('should create .rules with rules content when file does not exist', async () => {
       mockExists.mockResolvedValue(false);
 
-      await zed.update();
+      await zedCopilot.update();
 
       expect(mockExists).toHaveBeenCalledWith('./.rules');
       expect(mockReadFile).not.toHaveBeenCalled();
@@ -71,7 +71,7 @@ describe('zed configuration', () => {
       mockExists.mockResolvedValue(true);
       mockReadFile.mockResolvedValue(existingContent);
 
-      await zed.update();
+      await zedCopilot.update();
 
       expect(mockExists).toHaveBeenCalledWith('./.rules');
       expect(mockReadFile).toHaveBeenCalledWith('./.rules', 'utf-8');
@@ -87,7 +87,7 @@ describe('zed configuration', () => {
       mockExists.mockResolvedValue(true);
       mockReadFile.mockResolvedValue(existingContent);
 
-      await zed.update();
+      await zedCopilot.update();
 
       expect(mockExists).toHaveBeenCalledWith('./.rules');
       expect(mockReadFile).toHaveBeenCalledWith('./.rules', 'utf-8');
@@ -98,7 +98,7 @@ describe('zed configuration', () => {
       mockExists.mockResolvedValue(true);
       mockReadFile.mockRejectedValue(new Error('Permission denied'));
 
-      await expect(zed.update()).rejects.toThrow('Permission denied');
+      await expect(zedCopilot.update()).rejects.toThrow('Permission denied');
       expect(mockExists).toHaveBeenCalledWith('./.rules');
       expect(mockReadFile).toHaveBeenCalledWith('./.rules', 'utf-8');
     });
@@ -106,7 +106,7 @@ describe('zed configuration', () => {
     it('should handle exists check errors gracefully', async () => {
       mockExists.mockRejectedValue(new Error('Permission denied'));
 
-      await expect(zed.update()).rejects.toThrow('Permission denied');
+      await expect(zedCopilot.update()).rejects.toThrow('Permission denied');
       expect(mockExists).toHaveBeenCalledWith('./.rules');
     });
   });

--- a/__tests__/zed-settings.test.ts
+++ b/__tests__/zed-settings.test.ts
@@ -1,0 +1,314 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { exists } from '../scripts/utils';
+import { zed } from '../scripts/zed-settings';
+
+vi.mock('node:fs/promises');
+vi.mock('../scripts/utils', () => ({
+  exists: vi.fn(),
+}));
+
+describe('zed configuration', () => {
+  const mockReadFile = vi.mocked(readFile);
+  const mockWriteFile = vi.mocked(writeFile);
+  const mockExists = vi.mocked(exists);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('exists', () => {
+    it('should return true when .zed/settings.json exists', async () => {
+      mockExists.mockResolvedValue(true);
+
+      const result = await zed.exists();
+
+      expect(result).toBe(true);
+      expect(mockExists).toHaveBeenCalledWith('./.zed/settings.json');
+    });
+
+    it('should return false when .zed/settings.json does not exist', async () => {
+      mockExists.mockResolvedValue(false);
+
+      const result = await zed.exists();
+
+      expect(result).toBe(false);
+      expect(mockExists).toHaveBeenCalledWith('./.zed/settings.json');
+    });
+  });
+
+  describe('create', () => {
+    it('should create .zed/settings.json with default configuration', async () => {
+      await zed.create();
+
+      const expectedConfig = {
+        "formatter": "language_server",
+        "format_on_save": "on",
+        "languages": {
+          "TypeScript": {
+            "formatter": {
+              "language_server": {
+                "name": "biome"
+              },
+              "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+              }
+            }
+          },
+          "JavaScript": {
+            "formatter": {
+              "language_server": {
+                "name": "biome"
+              },
+              "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+              }
+            }
+          },
+          "TSX": {
+            "formatter": {
+              "language_server": {
+                "name": "biome"
+              },
+              "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+              }
+            }
+          },
+          "JSON": {
+            "formatter": {
+              "language_server": {
+                "name": "biome"
+              },
+              "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+              }
+            }
+          },
+          "JSONC": {
+            "formatter": {
+              "language_server": {
+                "name": "biome"
+              },
+              "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+              }
+            }
+          }
+        },
+        "lsp": {
+          "typescript-language-server": {
+            "settings": {
+              "typescript": {
+                "preferences": {
+                  "includePackageJsonAutoImports": "on"
+                }
+              }
+            }
+          }
+        }
+      };
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        JSON.stringify(expectedConfig, null, 2)
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should merge existing configuration with default configuration', async () => {
+      const existingConfig = {
+        "ui_font_size": 16,
+        "vim_mode": true,
+        "restore_on_startup": "none",
+      };
+
+      mockReadFile.mockResolvedValue(JSON.stringify(existingConfig));
+
+      await zed.update();
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        'utf-8'
+      );
+
+      // Verify that writeFile was called with merged configuration
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"ui_font_size": 16')
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"restore_on_startup": "none"')
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"vim_mode": true')
+      );
+    });
+
+    it('should preserve existing biome configuration while adding missing parts', async () => {
+      const existingConfig = {
+        "ui_font_size": 16,
+        "vim_mode": true,
+        "restore_on_startup": "none",
+      };
+
+      mockReadFile.mockResolvedValue(JSON.stringify(existingConfig));
+
+      await zed.update();
+
+      // Should merge the nested configuration properly
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"formatter": "language_server"')
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"ui_font_size": 16')
+      );
+    });
+
+    it('should handle invalid JSON by treating it as empty config', async () => {
+      mockReadFile.mockResolvedValue('invalid json');
+
+      await zed.update();
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        'utf-8'
+      );
+
+      // When parsing fails, jsonc-parser returns undefined,
+      // so deepmerge treats it as merging with undefined (effectively just using defaultConfig)
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        JSON.stringify(
+          {
+            "formatter": "language_server",
+            "format_on_save": "on",
+            "languages": {
+              "TypeScript": {
+                "formatter": {
+                  "language_server": {
+                    "name": "biome"
+                  },
+                  "code_actions_on_format": {
+                    "source.fixAll.biome": true,
+                    "source.organizeImports.biome": true
+                  }
+                }
+              },
+              "JavaScript": {
+                "formatter": {
+                  "language_server": {
+                    "name": "biome"
+                  },
+                  "code_actions_on_format": {
+                    "source.fixAll.biome": true,
+                    "source.organizeImports.biome": true
+                  }
+                }
+              },
+              "TSX": {
+                "formatter": {
+                  "language_server": {
+                    "name": "biome"
+                  },
+                  "code_actions_on_format": {
+                    "source.fixAll.biome": true,
+                    "source.organizeImports.biome": true
+                  }
+                }
+              },
+              "JSON": {
+                "formatter": {
+                  "language_server": {
+                    "name": "biome"
+                  },
+                  "code_actions_on_format": {
+                    "source.fixAll.biome": true,
+                    "source.organizeImports.biome": true
+                  }
+                }
+              },
+              "JSONC": {
+                "formatter": {
+                  "language_server": {
+                    "name": "biome"
+                  },
+                  "code_actions_on_format": {
+                    "source.fixAll.biome": true,
+                    "source.organizeImports.biome": true
+                  }
+                }
+              }
+            },
+            "lsp": {
+              "typescript-language-server": {
+                "settings": {
+                  "typescript": {
+                    "preferences": {
+                      "includePackageJsonAutoImports": "on"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          null,
+          2
+        )
+      );
+    });
+
+    it('should handle .jsonc files with comments', async () => {
+      const existingConfigWithComments = `{
+        // UI Font Size
+        "ui_font_size": 16,
+
+        /* Vim mode */
+        "vim_mode": true,
+
+        // Restore on startup option
+        "restore_on_startup": "none",
+      }`;
+
+      mockReadFile.mockResolvedValue(existingConfigWithComments);
+
+      await zed.update();
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        'utf-8'
+      );
+
+      // Verify that the JSONC content was properly parsed and merged
+      // Note: Comments are not preserved in the output (limitation of JSON.stringify)
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"ui_font_size": 16')
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"restore_on_startup": "none"')
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining(
+          '"formatter": "language_server"'
+        )
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        './.zed/settings.json',
+        expect.stringContaining('"vim_mode": true')
+      );
+    });
+  });
+});

--- a/scripts/initialize.ts
+++ b/scripts/initialize.ts
@@ -14,7 +14,8 @@ import { tsconfig } from './tsconfig';
 import { vscodeCopilot } from './vscode-copilot';
 import { vscode } from './vscode-settings';
 import { windsurf } from './windsurf';
-import { zed } from './zed';
+import { zedCopilot } from './zed-copilot';
+import { zed } from './zed-settings';
 
 const installDependencies = (packageManagerAdd: string) => {
   const s = spinner();
@@ -49,6 +50,22 @@ const upsertVSCodeSettings = async () => {
   if (await vscode.exists()) {
     s.message('settings.json found, updating...');
     await vscode.update();
+    s.stop('settings.json updated.');
+    return;
+  }
+
+  s.message('settings.json not found, creating...');
+  await vscode.create();
+  s.stop('settings.json created.');
+};
+
+const upsertZedSettings = async () => {
+  const s = spinner();
+  s.start('Checking for .zed/settings.json...');
+
+  if (await zed.exists()) {
+    s.message('settings.json found, updating...');
+    await zed.update();
     s.stop('settings.json updated.');
     return;
   }
@@ -186,9 +203,9 @@ const upsertZedRules = async () => {
   const s = spinner();
   s.start('Checking for Zed rules...');
 
-  if (await zed.exists()) {
+  if (await zedCopilot.exists()) {
     s.message('Zed rules found, updating...');
-    await zed.update();
+    await zedCopilot.update();
     s.stop('Zed rules updated.');
     return;
   }
@@ -272,26 +289,31 @@ export const initialize = async () => {
 
     installDependencies(packageManagerAdd);
     await upsertTsConfig();
-    await upsertVSCodeSettings();
     await upsertBiomeConfig();
 
     if (Array.isArray(editorRules)) {
       if (editorRules.includes('vscode-copilot')) {
+        await upsertVSCodeSettings();
         await upsertVSCodeCopilotRules();
       }
       if (editorRules.includes('cursor')) {
+        await upsertVSCodeSettings();
         await upsertCursorRules();
       }
       if (editorRules.includes('windsurf')) {
+        await upsertVSCodeSettings();
         await upsertWindsurfRules();
       }
       if (editorRules.includes('zed')) {
+        await upsertZedSettings();
         await upsertZedRules();
       }
       if (editorRules.includes('claude')) {
+        await upsertVSCodeSettings();
         await upsertClaudeRules();
       }
       if (editorRules.includes('codex')) {
+        await upsertVSCodeSettings();
         await upsertCodexRules();
       }
     }

--- a/scripts/zed-copilot.ts
+++ b/scripts/zed-copilot.ts
@@ -4,7 +4,7 @@ import { exists } from './utils';
 
 const path = './.rules';
 
-export const zed = {
+export const zedCopilot = {
   exists: () => exists(path),
   create: async () => {
     await writeFile(path, rulesFile);

--- a/scripts/zed-settings.ts
+++ b/scripts/zed-settings.ts
@@ -1,0 +1,97 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import deepmerge from 'deepmerge';
+import { parse } from 'jsonc-parser';
+import { exists } from './utils';
+
+const defaultConfig = {
+  "formatter": "language_server",
+  "format_on_save": "on",
+  "languages": {
+    "TypeScript": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        },
+        "code_actions_on_format": {
+          "source.fixAll.biome": true,
+          "source.organizeImports.biome": true
+        }
+      }
+    },
+    "JavaScript": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        },
+        "code_actions_on_format": {
+          "source.fixAll.biome": true,
+          "source.organizeImports.biome": true
+        }
+      }
+    },
+    "TSX": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        },
+        "code_actions_on_format": {
+          "source.fixAll.biome": true,
+          "source.organizeImports.biome": true
+        }
+      }
+    },
+    "JSON": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        },
+        "code_actions_on_format": {
+          "source.fixAll.biome": true,
+          "source.organizeImports.biome": true
+        }
+      }
+    },
+    "JSONC": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        },
+        "code_actions_on_format": {
+          "source.fixAll.biome": true,
+          "source.organizeImports.biome": true
+        }
+      }
+    }
+  },
+  "lsp": {
+    "typescript-language-server": {
+      "settings": {
+        "typescript": {
+          "preferences": {
+            "includePackageJsonAutoImports": "on"
+          }
+        }
+      }
+    }
+  }
+};
+
+const path = './.zed/settings.json';
+
+export const zed = {
+  exists: () => exists(path),
+  create: async () => {
+    await mkdir('.zed', { recursive: true });
+    await writeFile(path, JSON.stringify(defaultConfig, null, 2));
+  },
+  update: async () => {
+    const existingContents = await readFile(path, 'utf-8');
+    const existingConfig = parse(existingContents) as Record<string, unknown> | undefined;
+
+    // If parsing fails (invalid JSON), treat as empty config and proceed gracefully
+    const configToMerge = existingConfig || {};
+    const newConfig = deepmerge(configToMerge, defaultConfig);
+
+    await writeFile(path, JSON.stringify(newConfig, null, 2));
+  },
+};


### PR DESCRIPTION
Resolves #190

## Description

- Rename __tests__/zed.test.ts to __tests__/zed-copilot.test.ts and update imports
- Split scripts/zed.ts into scripts/zed-copilot.ts and scripts/zed-settings.ts
- Add zed-settings module for managing .zed/settings.json configuration
- Update initialize script to handle upserting zed settings and copilot rules
- Add tests for zed-settings configuration handling and merging

## Related Issues

Closes #<issue_number>

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Additional Notes

Got annoyed that even when selecting Zed, it kept adding `.vscode/settings.json` file. 
