### PR TITLE
feat: update filename convention rule to support $ prefix

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -508,7 +508,7 @@
           "options": {
             "requireAscii": true,
             "filenameCases": ["kebab-case"],
-            "match": "[$-?%]?(.+?)[.](.+)"
+            "match": "[\\-$]?(.+?)[.](.+)"
           }
         },
         // This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.


### PR DESCRIPTION
## Description

This pull request enhances the file naming convention support in Ultracite by adding support for $ prefixed files. The change updates the useFilenamingConvention rule in biome.jsonc to allow filenames starting with $ character, which is commonly used in TanStack Router for dynamic route segments (e.g., $slug.tsx, $id.tsx).

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.
