### PR TITLE
feat: add --skip-install flag to skip installing dependencies

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -49,6 +49,10 @@ const router = t.router({
           .boolean()
           .optional()
           .describe('Remove ESLint dependencies and configuration'),
+        skipInstall: z
+          .boolean()
+          .default(false)
+          .describe('Skip installing dependencies'),
       })
     )
     .mutation(async ({ input }) => {


### PR DESCRIPTION
## Description

Adds a new `skipInstall` option that allows users to skip dependency installation during initialization.

## Related Issues

Closes none

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<img width="1900" height="1580" alt="image" src="https://github.com/user-attachments/assets/c95f19fb-40b7-46d9-b963-fc27b4857f9b" />

