### PR TITLE
use trpc-cli with peerDependencies

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
-import { type TrpcCliMeta, trpcServer } from 'trpc-cli';
+import { initTRPC } from '@trpc/server';
+import type { TrpcCliMeta } from 'trpc-cli';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import z from 'zod';
 
@@ -27,7 +28,7 @@ vi.mock('../package.json', () => ({
 }));
 
 function createTestRouter() {
-  const t = trpcServer.initTRPC.meta<TrpcCliMeta>().create();
+  const t = initTRPC.meta<TrpcCliMeta>().create();
 
   return t.router({
     init: t.procedure

--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "@trpc/server": "^11.4.4",
     "deepmerge": "^4.3.1",
     "jsonc-parser": "^3.3.1",
     "nypm": "^0.6.1",
-    "trpc-cli": "^0.10.0",
+    "trpc-cli": "https://pkg.pr.new/mmkal/trpc-cli@146",
     "vitest": "^3.2.4",
     "zod": "^4.0.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@trpc/server':
+        specifier: ^11.4.4
+        version: 11.4.4(typescript@5.8.3)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -21,8 +24,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       trpc-cli:
-        specifier: ^0.10.0
-        version: 0.10.2(typescript@5.8.3)
+        specifier: https://pkg.pr.new/mmkal/trpc-cli@146
+        version: https://pkg.pr.new/mmkal/trpc-cli@146(@trpc/server@11.4.4(typescript@5.8.3))(zod@4.0.14)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)
@@ -520,8 +523,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@trpc/server@11.4.3':
-    resolution: {integrity: sha512-wnWq3wiLlMOlYkaIZz+qbuYA5udPTLS4GVVRyFkr6aT83xpdCHyVtURT+u4hSoIrOXQM9OPCNXSXsAujWZDdaw==}
+  '@trpc/server@11.4.4':
+    resolution: {integrity: sha512-VkJb2xnb4rCynuwlCvgPBh5aM+Dco6fBBIo6lWAdJJRYVwtyE5bxNZBgUvRRz/cFSEAy0vmzLxF7aABDJfK5Rg==}
     peerDependencies:
       typescript: '>=5.7.2'
 
@@ -548,9 +551,6 @@ packages:
 
   '@types/node@24.1.0':
     resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
-
-  '@types/omelette@0.4.5':
-    resolution: {integrity: sha512-zUCJpVRwfMcZfkxSCGp73mgd3/xesvPz5tQJIORlfP/zkYEyp9KUfF7IP3RRjyZR3DwxkPs96/IFf70GmYZYHQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -1939,17 +1939,30 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  trpc-cli@0.10.2:
-    resolution: {integrity: sha512-zBkL88AeX0vQLXwEAcX6WUoT4Sopr97nFDFeD1zmW33wHQwBKbszylplNVk6BO/cuhgm/iq8/cG27NokqKA1mw==}
+  trpc-cli@https://pkg.pr.new/mmkal/trpc-cli@146:
+    resolution: {tarball: https://pkg.pr.new/mmkal/trpc-cli@146}
+    version: 0.0.0-dev-20250808154834
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      '@inquirer/prompts': '*'
-      omelette: '*'
+      '@orpc/server': ^1.0.0
+      '@trpc/server': ^10.45.2 || ^11.0.1
+      '@valibot/to-json-schema': ^1.1.0
+      effect: ^3.14.2 || ^4.0.0
+      valibot: ^1.1.0
+      zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
-      '@inquirer/prompts':
+      '@orpc/server':
         optional: true
-      omelette:
+      '@trpc/server':
+        optional: true
+      '@valibot/to-json-schema':
+        optional: true
+      effect:
+        optional: true
+      valibot:
+        optional: true
+      zod:
         optional: true
 
   ts-interface-checker@0.1.13:
@@ -2198,14 +2211,6 @@ packages:
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
-
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.0.14:
     resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
@@ -2667,7 +2672,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.44.0':
     optional: true
 
-  '@trpc/server@11.4.3(typescript@5.8.3)':
+  '@trpc/server@11.4.4(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
@@ -2690,8 +2695,6 @@ snapshots:
   '@types/node@24.1.0':
     dependencies:
       undici-types: 7.8.0
-
-  '@types/omelette@0.4.5': {}
 
   '@types/parse-json@4.0.2': {}
 
@@ -4190,16 +4193,12 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  trpc-cli@0.10.2(typescript@5.8.3):
+  trpc-cli@https://pkg.pr.new/mmkal/trpc-cli@146(@trpc/server@11.4.4(typescript@5.8.3))(zod@4.0.14):
     dependencies:
-      '@trpc/server': 11.4.3(typescript@5.8.3)
-      '@types/omelette': 0.4.5
       commander: 14.0.0
-      picocolors: 1.1.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - typescript
+    optionalDependencies:
+      '@trpc/server': 11.4.4(typescript@5.8.3)
+      zod: 4.0.14
 
   ts-interface-checker@0.1.13: {}
 
@@ -4506,11 +4505,5 @@ snapshots:
       yargs-parser: 18.1.3
 
   yn@3.1.1: {}
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
 
   zod@4.0.14: {}

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { createCli, type TrpcCliMeta, trpcServer } from 'trpc-cli';
+import { initTRPC } from '@trpc/server';
+import { createCli, type TrpcCliMeta } from 'trpc-cli';
 import z from 'zod';
 import packageJson from '../package.json' with { type: 'json' };
 import { format } from './commands/format';
@@ -8,7 +9,7 @@ import { lint } from './commands/lint';
 import { options } from './consts/options';
 import { initialize } from './initialize';
 
-const t = trpcServer.initTRPC.meta<TrpcCliMeta>().create();
+const t = initTRPC.meta<TrpcCliMeta>().create();
 
 const router = t.router({
   init: t.procedure


### PR DESCRIPTION
## Description

_draft, using pkg-pr-new until a real vesrion is published_

Just trying out https://github.com/mmkal/trpc-cli/pull/146 - I want to stop bundling zod+trpc in trpc-cli. It's a good thing for you because there will no longer be an unnecessary version of zod in node_modules (tradeoff is that you have to add @trpc/server to package.json and import separately, but that's about it). Should make bundling CLIs less error-prone too - no more eval hacks.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.
