### PR TITLE
DOCS : Fix error in the troubleshooting page

### DIFF
--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -33,11 +33,10 @@ To do this, add patterns to your `biome.jsonc` to exclude those files i.e.
 {
   "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
   "extends": ["ultracite"],
-  "ignore": ["/components/ui/**", "/lib/**", "/hooks/**"],
   "files": {
     "includes": [
       "**/*",
-      "!component/ui",
+      "!components/ui",
       "!lib",
       "!hooks",
     ]


### PR DESCRIPTION
Following #252 update, I misspelled the `components` folder in my update, and I forgot to remove the (not compatible anymore) biome `ignore` key.

Thanks you for your great work .