### PR TITLE
Replace execSync commands with spawnSync

### DIFF
--- a/scripts/commands/lint.ts
+++ b/scripts/commands/lint.ts
@@ -1,15 +1,28 @@
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import process from 'node:process';
 
 export const lint = (files: string[]) => {
-  try {
-    const target =
-      files.length > 0 ? files.map((file) => `"${file}"`).join(' ') : './';
-    execSync(`npx @biomejs/biome check ${target}`, { stdio: 'inherit' });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+  const args = ['@biomejs/biome', 'check'];
+
+  // Add files or default to current directory
+  if (files.length > 0) {
+    args.push(...files);
+  } else {
+    args.push('./');
+  }
+
+  const result = spawnSync('npx', args, {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (result.error) {
     // biome-ignore lint/suspicious/noConsole: "We want to log the error to the console"
-    console.error('Failed to run Ultracite:', message);
+    console.error('Failed to run Ultracite:', result.error.message);
     process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
   }
 };


### PR DESCRIPTION
This pull request refactors the implementation and tests for the `lint` and `format` commands to use `spawnSync` instead of `execSync` for running Biome commands. It also updates error handling to check process exit status and error objects from `spawnSync`, ensuring more robust and accurate process management. The test suites for both commands are updated to mock and verify the new behavior.

**Command Implementation Refactor:**

* Replaced usage of `execSync` with `spawnSync` in both `scripts/commands/format.ts` and `scripts/commands/lint.ts`, updating argument handling to pass command and arguments as arrays, and setting `{ shell: false }` for better security and reliability. [[1]](diffhunk://#diff-665a80f72d7fc186b716ad331c8d959c1ca83e217df407bd4eeadd29e8e9e6a1L1-R35) [[2]](diffhunk://#diff-d206be0ec4a6180b9d4305d8d0261516bcae1cf313bc3f1e7ea30d4d4f34eafbL1-R27)
* Updated error handling to check for errors and non-zero exit status from `spawnSync`, logging errors and exiting with the correct status code. [[1]](diffhunk://#diff-665a80f72d7fc186b716ad331c8d959c1ca83e217df407bd4eeadd29e8e9e6a1L1-R35) [[2]](diffhunk://#diff-d206be0ec4a6180b9d4305d8d0261516bcae1cf313bc3f1e7ea30d4d4f34eafbL1-R27)

**Test Suite Updates:**

* Refactored tests in `__tests__/format.test.ts` and `__tests__/lint.test.ts` to mock and verify `spawnSync` calls instead of `execSync`, including argument structure and options. [[1]](diffhunk://#diff-59db2e07472dbab296df610eee04e5fb31537f16b2027309cbfcf4fddaf52d22L1-R31) [[2]](diffhunk://#diff-4f3062be29ffb89d752e2f72862f99103cc8d0a40c78bb0b6bfba5bd09e2f31aL1-R56)
* Updated tests to check handling of non-zero exit status and error objects returned by `spawnSync`, ensuring the commands exit with the correct status and error logging. [[1]](diffhunk://#diff-59db2e07472dbab296df610eee04e5fb31537f16b2027309cbfcf4fddaf52d22L76-R104) [[2]](diffhunk://#diff-59db2e07472dbab296df610eee04e5fb31537f16b2027309cbfcf4fddaf52d22L91-R129) [[3]](diffhunk://#diff-4f3062be29ffb89d752e2f72862f99103cc8d0a40c78bb0b6bfba5bd09e2f31aL65-R95) [[4]](diffhunk://#diff-4f3062be29ffb89d752e2f72862f99103cc8d0a40c78bb0b6bfba5bd09e2f31aL80-R120)
* Simplified file argument handling in tests to match the new array-based approach for passing file paths. [[1]](diffhunk://#diff-59db2e07472dbab296df610eee04e5fb31537f16b2027309cbfcf4fddaf52d22L30-R65) [[2]](diffhunk://#diff-59db2e07472dbab296df610eee04e5fb31537f16b2027309cbfcf4fddaf52d22L63-R85) [[3]](diffhunk://#diff-4f3062be29ffb89d752e2f72862f99103cc8d0a40c78bb0b6bfba5bd09e2f31aL52-R76)
* 

Resolves #193
Resolves #203