### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,6 +1,10 @@
 # Name of our action
 name: Release
 
+permissions:
+  contents: read
+  pull-requests: write
+
 # The event that will trigger the action
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/haydenbleasel/ultracite/security/code-scanning/8](https://github.com/haydenbleasel/ultracite/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating or updating pull requests (if applicable).
- Additional permissions (e.g., `issues: write`) can be added if required by specific steps.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `release` job to scope permissions to that job only. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
