### PR TITLE
Update monorepos.mdx turbo task names

### DIFF
--- a/docs/content/monorepos.mdx
+++ b/docs/content/monorepos.mdx
@@ -38,8 +38,8 @@ Optionally, you can also add the `check` and `fix` scripts to your `turbo.json` 
 ```json title="turbo.json"
 {
   "tasks": {
-    "//#format": {},
-    "//#lint": {
+    "//#check": {},
+    "//#fix": {
       "cache": false
     }
   }


### PR DESCRIPTION
## Description

In docs monorepo page the turbo tasks weren't the same as the package.json scripts.