### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: Validate
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/haydenbleasel/ultracite/security/code-scanning/12](https://github.com/haydenbleasel/ultracite/security/code-scanning/12)

To fix this problem, you should add an explicit `permissions:` block to the workflow YAML file, either at the top-level (affecting all jobs unless overridden) or at the job level (per job). Since neither the `build` nor `test` jobs appear to require any write permissions or access beyond the ability to read repository contents, setting `permissions: contents: read` at the top-level is sufficient and provides the least-privilege policy. No existing functionality will be changed by this adjustment; jobs will still have the minimal read access necessary to check out the code.

You should add the following lines immediately after the `name: Validate` block and before `on:` (line 2), or at the top of the YAML file, making sure to use proper indentation:
```yaml
permissions:
  contents: read
```
No additional imports, methods, or changes elsewhere are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
