### PR TITLE
fix(docs): fix 404 links in configuration section

### DIFF
--- a/apps/docs/content/(docs)/configuration.mdx
+++ b/apps/docs/content/(docs)/configuration.mdx
@@ -41,14 +41,14 @@ You can combine multiple configurations if you're working on a multi-framework p
 
 Each framework configuration includes rules specific to that framework. Click the links above to see detailed documentation for each configuration:
 
-- **[React](/react)**: JSX rules, hooks rules, component rules
-- **[Next.js](/next)**: Image optimization, document structure, client components
-- **[Solid](/solid)**: Reactivity rules, component patterns, props handling
-- **[Vue](/vue)**: Component structure, computed properties, data options
-- **[Svelte](/svelte)**: Standard HTML attributes, no React-specific props
-- **[Qwik](/qwik)**: Serialization, visible tasks, dollar scopes
-- **[Angular](/angular)**: HTML parser with interpolation support for templates
-- **[Remix](/remix)**: Filename conventions for route files
+- **[React](/preset/react)**: JSX rules, hooks rules, component rules
+- **[Next.js](/preset/next)**: Image optimization, document structure, client components
+- **[Solid](/preset/solid)**: Reactivity rules, component patterns, props handling
+- **[Vue](/preset/vue)**: Component structure, computed properties, data options
+- **[Svelte](/preset/svelte)**: Standard HTML attributes, no React-specific props
+- **[Qwik](/preset/qwik)**: Serialization, visible tasks, dollar scopes
+- **[Angular](/preset/angular)**: HTML parser with interpolation support for templates
+- **[Remix](/preset/remix)**: Filename conventions for route files
 
 ## Default configuration
 


### PR DESCRIPTION
## Description

Fixed broken framework links in the Configuration page.  
They previously pointed to `/react`, `/next`, etc., which led to 404s.  
Now they correctly point to `/preset/<framework>` pages.

## Related Issues

-

## Checklist

- [x] My changes follow the docs style and structure.
- [x] I reviewed the pages locally to confirm links work.

## Screenshots (if applicable)

**Before (broken links):** 

https://github.com/user-attachments/assets/51c03abc-139d-4a2d-9a49-e3869fc61a99

**After (fixed links):**

https://github.com/user-attachments/assets/80278403-63d2-41d5-b96d-f95fef39d1fe

## Additional Notes

Just a small docs fix to improve navigation.., nothing major, but makes the docs smoother to explore.
