### PR TITLE
Fix overrides in Astro/Svelte/Vue presets having no effect

### DIFF
--- a/.changeset/legal-bottles-brake.md
+++ b/.changeset/legal-bottles-brake.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Fix overrides in Astro, Svelte, Vue presets having no effect

--- a/packages/cli/config/astro/biome.jsonc
+++ b/packages/cli/config/astro/biome.jsonc
@@ -9,7 +9,7 @@
 	},
 	"overrides": [
 		{
-			"includes": ["*.astro"],
+			"includes": ["**/*.astro"],
 			"linter": {
 				"rules": {
 					"correctness": {

--- a/packages/cli/config/svelte/biome.jsonc
+++ b/packages/cli/config/svelte/biome.jsonc
@@ -9,7 +9,7 @@
 	},
 	"overrides": [
 		{
-			"includes": ["*.svelte"],
+			"includes": ["**/*.svelte"],
 			"linter": {
 				"rules": {
 					"correctness": {

--- a/packages/cli/config/vue/biome.jsonc
+++ b/packages/cli/config/vue/biome.jsonc
@@ -9,7 +9,7 @@
 	},
 	"overrides": [
 		{
-			"includes": ["*.vue"],
+			"includes": ["**/*.vue"],
 			"linter": {
 				"rules": {
 					"nursery": {


### PR DESCRIPTION
## Description

The overrides in the current Astro/Svelte/Vue configs have no effect because the glob patterns used in `includes` field are malformed. This PR fixes it.

## Related Issues

Closes #350

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->

Somewhat related to https://github.com/haydenbleasel/ultracite/issues/332#issuecomment-3460009213
