### PR TITLE
fix(docs): correct preset link path in configuration

### DIFF
--- a/apps/docs/content/(docs)/configuration.mdx
+++ b/apps/docs/content/(docs)/configuration.mdx
@@ -7,7 +7,7 @@ One of Ultracite's best features is that it's zero-config out of the box – you
 
 Ultracite provides framework-specific configurations that you can extend in addition to the base configuration. This allows you to add framework-specific linting rules without bloating the base config or dealing with irrelevant rules.
 
-You can find the full list of available framework configurations in the [Presets](/preset) section.
+You can find the full list of available framework configurations in the [Presets](/preset/core) section.
 
 ### Usage
 


### PR DESCRIPTION
## Description

Fixed a broken link in the configuration documentation page. The link to the Presets section was pointing to `/preset` which does not exist. Updated it to point to the correct path `/preset/core` where the core preset documentation is located.

## Related Issues
N/A

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.