### PR TITLE
fix: fix locale nav links in docs

### DIFF
--- a/apps/docs/components/navbar.tsx
+++ b/apps/docs/components/navbar.tsx
@@ -18,7 +18,14 @@ const links = [
 
 export const Navbar = () => {
   const pathname = usePathname();
-  const { lang } = useParams();
+  const params = useParams();
+  const langParam = params?.lang;
+  const lang =
+    typeof langParam === "string"
+      ? langParam
+      : Array.isArray(langParam)
+        ? langParam.join("/")
+        : undefined;
 
   return (
     <div className="sticky top-0 z-50 w-full bg-background/90 py-3 backdrop-blur-sm">
@@ -33,11 +40,19 @@ export const Navbar = () => {
               <DynamicLink
                 className={cn(
                   "text-muted-foreground hover:text-primary",
-                  (link.exact
-                    ? pathname === link.href
-                    : pathname.startsWith(link.href)) && "text-primary"
+                  (() => {
+                    const resolvedHref = lang
+                      ? link.href.replace("[lang]", lang)
+                      : link.href;
+                    if (!pathname) {
+                      return false;
+                    }
+                    return link.exact
+                      ? pathname === resolvedHref
+                      : pathname.startsWith(resolvedHref);
+                  })() && "text-primary"
                 )}
-                href={`/${lang}${link.href}`}
+                href={link.href}
                 key={link.href}
               >
                 {link.label}


### PR DESCRIPTION
## Description

Changing the language on `/` and then using the navbar to open another page duplicated the locale segment (e.g., `/da/da/introduction`). This update keeps the link targets clean by always passing the `[lang]` placeholder to `DynamicLink` and only resolving it locally for the active-state check.

**Reproduction steps**
1. Open `/`.
2. Use the language toggle to switch to another locale (e.g., Danish).
3. Click `Docs` in the navbar.
4. Notice the stale behavior navigates to `/da/da/introduction`; after this fix it goes to `/da/introduction`.

## Related Issues

Closes #<issue_number>

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
