### PR TITLE
Update footer navigation to use docsUrl for documentation link

### DIFF
--- a/apps/web/components/footer/navigation.tsx
+++ b/apps/web/components/footer/navigation.tsx
@@ -1,6 +1,6 @@
 import { SiX } from "@icons-pack/react-simple-icons";
 import { agents } from "@repo/data/src/agents";
-import { statusUrl } from "@repo/data/src/consts";
+import { docsUrl, statusUrl } from "@repo/data/src/consts";
 import { editors } from "@repo/data/src/editors";
 import { providers } from "@repo/data/src/providers";
 import { Logo } from "@repo/design-system/components/ultracite/logo";
@@ -31,7 +31,7 @@ const generalLinks = [
     label: "Cloud",
   },
   {
-    href: "/docs",
+    href: docsUrl,
     label: "Docs",
   },
   {


### PR DESCRIPTION
## Description

The footer navigation was using `/docs`, when the docs were changed to docs.ultracite.ai. This was leading to a 404.

## Checklist

- [X] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

