### PR TITLE
docs: fix open in github url

### DIFF
--- a/apps/docs/app/[[...slug]]/page.tsx
+++ b/apps/docs/app/[[...slug]]/page.tsx
@@ -31,7 +31,7 @@ const Page = async (props: PageProps<"/[[...slug]]">) => {
       <div className="-mt-6 mb-6 flex flex-row items-center gap-2">
         <CopyMarkdown markdown={markdown} />
         <ViewOptions
-          githubUrl={`https://github.com/haydenbleasel/ultracite/blob/main/apps/docs/content/${page.path}`}
+          githubUrl={`https://github.com/haydenbleasel/ultracite/blob/main/apps/docs/content/docs/${page.path}`}
           markdownUrl={`${page.url}.mdx`}
         />
       </div>


### PR DESCRIPTION
## Description

Fixing the open in Github option which opens docs pages to a 404 Github page (maybe since v7.0)

Wrong generated url example (now in main)
`https://github.com/haydenbleasel/ultracite/blob/main/apps/docs/content/sponsors.mdx`
Fix now
`https://github.com/haydenbleasel/ultracite/blob/main/apps/docs/content/docs/sponsors.mdx`
