### PR TITLE
Disable `require-await`

### DIFF
--- a/.changeset/fine-camels-cut.md
+++ b/.changeset/fine-camels-cut.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Disable typescript/require-await

--- a/packages/cli/config/oxlint/core/.oxlintrc.json
+++ b/packages/cli/config/oxlint/core/.oxlintrc.json
@@ -78,6 +78,7 @@
     "typescript/no-require-imports": "off",
     "typescript/explicit-function-return-type": "off",
     "typescript/no-var-requires": "off",
+    "typescript/require-await":"off",
 
     "node/no-process-env": "off",
 


### PR DESCRIPTION
## Description

`require-await` is conflicting with `typescript-eslint/require-await`, and it's often false-negative due to lack of type information, for instance, `async () => import('....')`, where it doesn't know if the function call is a promise.

https://github.com/user-attachments/assets/0ee7cf1a-f64a-4133-b8f1-af9934bd98ae

