### PR TITLE
Fix invalid oxlint `func-style`

### DIFF
--- a/packages/cli/config/oxlint/core/.oxlintrc.json
+++ b/packages/cli/config/oxlint/core/.oxlintrc.json
@@ -35,9 +35,9 @@
     "id-length": "off",
     "func-style": [
       "error",
+      "expression",
       {
-        "allowArrowFunctions": true,
-        "style": "expression"
+        "allowArrowFunctions": true
       }
     ],
     "arrow-body-style": ["error", "as-needed"],


### PR DESCRIPTION
## Description

Fix invalid oxlint `func-style` rule configuration to match schema requirements, preventing `ultracite fix` from failing during config parsing.

## Related Issues

Closes #551

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes

No behavior change beyond correcting the oxlint config schema.
