### PR TITLE
Fix DEP0190 warnings for Windows command execution

### DIFF
--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -64,6 +64,33 @@ describe("check", () => {
     expect(callArgs[1]).toContain("--error-on-warnings");
   });
 
+  test("retries with .cmd when command is missing on Windows", async () => {
+    const mockSpawn = mock((command: string) => {
+      if (command === "biome") {
+        return {
+          error: { code: "ENOENT", message: "missing binary" },
+          status: null,
+        };
+      }
+
+      return { status: 0 };
+    });
+    mock.module("node:child_process", () => ({
+      spawnSync: mockSpawn,
+    }));
+    mock.module("../src/utils", () => ({
+      detectLinter: mock(() => Promise.resolve("biome")),
+      parseFilePaths,
+    }));
+
+    await check();
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = mockSpawn.mock.calls;
+    expect(firstCall[0]).toBe("biome");
+    expect(secondCall[0]).toBe("biome.cmd");
+  });
+
   test("handles files with special characters", async () => {
     const mockSpawn = mock(() => ({ status: 0 }));
     mock.module("node:child_process", () => ({
@@ -78,7 +105,7 @@ describe("check", () => {
 
     expect(mockSpawn).toHaveBeenCalled();
     const [callArgs] = mockSpawn.mock.calls;
-    expect(callArgs[1]).toContain("'src/my file.ts' ");
+    expect(callArgs[1]).toContain("src/my file.ts");
   });
 
   test("exits with status code when biome check finds errors", async () => {

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -82,6 +82,43 @@ describe("doctor", () => {
     await expect(doctor()).rejects.toThrow("Doctor checks failed");
   });
 
+  test("retries with .cmd when version command is missing on Windows", async () => {
+    const mockSpawn = mock((command: string) => {
+      if (command === "biome") {
+        return {
+          error: { code: "ENOENT", message: "missing binary" },
+          status: null,
+          stdout: "",
+        };
+      }
+
+      return { status: 0, stdout: "1.0.0" };
+    });
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {
+      // noop
+    });
+
+    mock.module("node:child_process", () => ({
+      spawnSync: mockSpawn,
+    }));
+    mock.module("node:fs", () => ({
+      existsSync: mock(() => false),
+    }));
+    mock.module("node:fs/promises", () => ({
+      access: mock(() => Promise.resolve()),
+      readFile: mock(() => Promise.resolve("{}")),
+      writeFile: mock(() => Promise.resolve()),
+    }));
+
+    await doctor();
+
+    expect(mockSpawn).toHaveBeenCalled();
+    expect(mockSpawn.mock.calls.some((call) => call[0] === "biome.cmd")).toBe(
+      true
+    );
+    consoleLogSpy.mockRestore();
+  });
+
   test("warns when conflicting tools are present (prettier and eslint)", async () => {
     const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {
       // noop

--- a/packages/cli/__tests__/fix.test.ts
+++ b/packages/cli/__tests__/fix.test.ts
@@ -81,6 +81,33 @@ describe("fix", () => {
     expect(callArgs[1]).not.toContain("--unsafe");
   });
 
+  test("retries with .cmd when command is missing on Windows", async () => {
+    const mockSpawn = mock((command: string) => {
+      if (command === "biome") {
+        return {
+          error: { code: "ENOENT", message: "missing binary" },
+          status: null,
+        };
+      }
+
+      return { status: 0 };
+    });
+    mock.module("node:child_process", () => ({
+      spawnSync: mockSpawn,
+    }));
+    mock.module("../src/utils", () => ({
+      detectLinter: mock(() => Promise.resolve("biome")),
+      parseFilePaths,
+    }));
+
+    await fix([]);
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = mockSpawn.mock.calls;
+    expect(firstCall[0]).toBe("biome");
+    expect(secondCall[0]).toBe("biome.cmd");
+  });
+
   test("handles files with special characters", async () => {
     const mockSpawn = mock(() => ({ status: 0 }));
     mock.module("node:child_process", () => ({
@@ -95,7 +122,7 @@ describe("fix", () => {
 
     expect(mockSpawn).toHaveBeenCalled();
     const [callArgs] = mockSpawn.mock.calls;
-    expect(callArgs[1]).toContain("'src/my file.ts' ");
+    expect(callArgs[1]).toContain("src/my file.ts");
   });
 
   test("exits with status code when biome fix finds errors", async () => {

--- a/packages/cli/__tests__/utils.test.ts
+++ b/packages/cli/__tests__/utils.test.ts
@@ -191,36 +191,28 @@ describe("parseFilePaths", () => {
     expect(result).toEqual(files);
   });
 
-  test("wraps files with spaces in quotes", () => {
+  test("returns files with spaces unchanged", () => {
     const files = ["src/my file.ts", "test file.js"];
     const result = parseFilePaths(files);
-    expect(result).toEqual(["'src/my file.ts' ", "'test file.js' "]);
+    expect(result).toEqual(files);
   });
 
-  test("escapes single quotes in file paths", () => {
+  test("returns files with single quotes unchanged", () => {
     const files = ["src/user's file.ts"];
     const result = parseFilePaths(files);
-    expect(result).toEqual(["'src/user'\\''s file.ts' "]);
+    expect(result).toEqual(files);
   });
 
-  test("wraps files with special characters in quotes", () => {
+  test("returns files with special characters unchanged", () => {
     const files = ["src/file(1).ts", "test[2].js", "file&test.ts"];
     const result = parseFilePaths(files);
-    expect(result).toEqual([
-      "'src/file(1).ts' ",
-      "'test[2].js' ",
-      "'file&test.ts' ",
-    ]);
+    expect(result).toEqual(files);
   });
 
   test("handles mixed file paths", () => {
     const files = ["normal.ts", "with space.js", "user's.ts"];
     const result = parseFilePaths(files);
-    expect(result).toEqual([
-      "normal.ts",
-      "'with space.js' ",
-      "'user'\\''s.ts' ",
-    ]);
+    expect(result).toEqual(files);
   });
 });
 

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,7 +1,26 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
-import { detectLinter, parseFilePaths, shellOption } from "../utils";
+import { detectLinter, parseFilePaths } from "../utils";
+
+const runCommand = (
+  command: string,
+  args: string[],
+  options: Parameters<typeof spawnSync>[2]
+) => {
+  const result = spawnSync(command, args, options);
+  const isMissingCommand =
+    process.platform === "win32" &&
+    result.error &&
+    "code" in result.error &&
+    result.error.code === "ENOENT";
+
+  if (!isMissingCommand) {
+    return result;
+  }
+
+  return spawnSync(`${command}.cmd`, args, options);
+};
 
 const runBiomeCheck = (files: string[], passthrough: string[]): void => {
   const args = ["check", "--no-errors-on-unmatched", ...passthrough];
@@ -12,8 +31,7 @@ const runBiomeCheck = (files: string[], passthrough: string[]): void => {
     args.push("./");
   }
 
-  const result = spawnSync("biome", args, {
-    shell: shellOption,
+  const result = runCommand("biome", args, {
     stdio: "inherit",
   });
 
@@ -32,8 +50,7 @@ const runEslintCheck = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("eslint", args, {
-    shell: shellOption,
+  const result = runCommand("eslint", args, {
     stdio: "inherit",
   });
 
@@ -53,8 +70,7 @@ const runPrettierCheck = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("prettier", args, {
-    shell: shellOption,
+  const result = runCommand("prettier", args, {
     stdio: "inherit",
   });
 
@@ -73,8 +89,7 @@ const runStylelintCheck = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("stylelint", args, {
-    shell: shellOption,
+  const result = runCommand("stylelint", args, {
     stdio: "inherit",
   });
 
@@ -93,8 +108,7 @@ const runOxlintCheck = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("oxlint", args, {
-    shell: shellOption,
+  const result = runCommand("oxlint", args, {
     stdio: "inherit",
   });
 
@@ -114,8 +128,7 @@ const runOxfmtCheck = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("oxfmt", args, {
-    shell: shellOption,
+  const result = runCommand("oxfmt", args, {
     stdio: "inherit",
   });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -8,7 +8,24 @@ import { intro, log, outro, spinner } from "@clack/prompts";
 import { parse } from "jsonc-parser";
 
 import packageJson from "../../package.json" with { type: "json" };
-import { shellOption } from "../utils";
+const runCommand = (
+  command: string,
+  args: string[],
+  options: Parameters<typeof spawnSync>[2]
+) => {
+  const result = spawnSync(command, args, options);
+  const isMissingCommand =
+    process.platform === "win32" &&
+    result.error &&
+    "code" in result.error &&
+    result.error.code === "ENOENT";
+
+  if (!isMissingCommand) {
+    return result;
+  }
+
+  return spawnSync(`${command}.cmd`, args, options);
+};
 
 // Config files to check for conflicting tools
 const prettierConfigFiles = [
@@ -48,9 +65,8 @@ interface DiagnosticCheck {
 
 // Check if Biome is installed
 const checkBiomeInstallation = (): DiagnosticCheck => {
-  const biomeCheck = spawnSync("biome", ["--version"], {
+  const biomeCheck = runCommand("biome", ["--version"], {
     encoding: "utf8",
-    shell: shellOption,
   });
 
   if (biomeCheck.status === 0 && biomeCheck.stdout) {
@@ -70,9 +86,8 @@ const checkBiomeInstallation = (): DiagnosticCheck => {
 
 // Check if ESLint is installed
 const checkEslintInstallation = (): DiagnosticCheck => {
-  const eslintCheck = spawnSync("eslint", ["--version"], {
+  const eslintCheck = runCommand("eslint", ["--version"], {
     encoding: "utf8",
-    shell: shellOption,
   });
 
   if (eslintCheck.status === 0 && eslintCheck.stdout) {
@@ -92,9 +107,8 @@ const checkEslintInstallation = (): DiagnosticCheck => {
 
 // Check if Oxlint is installed
 const checkOxlintInstallation = (): DiagnosticCheck => {
-  const oxlintCheck = spawnSync("oxlint", ["--version"], {
+  const oxlintCheck = runCommand("oxlint", ["--version"], {
     encoding: "utf8",
-    shell: shellOption,
   });
 
   if (oxlintCheck.status === 0 && oxlintCheck.stdout) {

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -1,7 +1,26 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
-import { detectLinter, parseFilePaths, shellOption } from "../utils";
+import { detectLinter, parseFilePaths } from "../utils";
+
+const runCommand = (
+  command: string,
+  args: string[],
+  options: Parameters<typeof spawnSync>[2]
+) => {
+  const result = spawnSync(command, args, options);
+  const isMissingCommand =
+    process.platform === "win32" &&
+    result.error &&
+    "code" in result.error &&
+    result.error.code === "ENOENT";
+
+  if (!isMissingCommand) {
+    return result;
+  }
+
+  return spawnSync(`${command}.cmd`, args, options);
+};
 
 const runBiomeFix = (files: string[], passthrough: string[]): void => {
   const args = ["check", "--write", "--no-errors-on-unmatched", ...passthrough];
@@ -12,8 +31,7 @@ const runBiomeFix = (files: string[], passthrough: string[]): void => {
     args.push("./");
   }
 
-  const result = spawnSync("biome", args, {
-    shell: shellOption,
+  const result = runCommand("biome", args, {
     stdio: "inherit",
   });
 
@@ -33,8 +51,7 @@ const runEslintFix = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("eslint", args, {
-    shell: shellOption,
+  const result = runCommand("eslint", args, {
     stdio: "inherit",
   });
 
@@ -54,8 +71,7 @@ const runPrettierFix = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("prettier", args, {
-    shell: shellOption,
+  const result = runCommand("prettier", args, {
     stdio: "inherit",
   });
 
@@ -75,8 +91,7 @@ const runStylelintFix = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("stylelint", args, {
-    shell: shellOption,
+  const result = runCommand("stylelint", args, {
     stdio: "inherit",
   });
 
@@ -100,8 +115,7 @@ const runOxlintFix = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("oxlint", args, {
-    shell: shellOption,
+  const result = runCommand("oxlint", args, {
     stdio: "inherit",
   });
 
@@ -121,8 +135,7 @@ const runOxfmtFix = (files: string[], passthrough: string[]): void => {
     ...(files.length > 0 ? parseFilePaths(files) : ["."]),
   ];
 
-  const result = spawnSync("oxfmt", args, {
-    shell: shellOption,
+  const result = runCommand("oxfmt", args, {
     stdio: "inherit",
   });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -4,11 +4,6 @@ import process from "node:process";
 
 import { parse } from "jsonc-parser";
 
-// Windows needs shell: true to resolve .cmd binaries (e.g. biome.cmd).
-// Other platforms don't need it, and Node >= 22.12 emits DEP0190 when
-// args are passed with shell: true.
-export const shellOption = process.platform === "win32";
-
 export const exists = async (path: string) => {
   try {
     await access(path);
@@ -84,20 +79,10 @@ export const updatePackageJson = async ({
   );
 };
 
-// Regex patterns for special characters that need escaping
-const SPECIAL_CHARS_PATTERN = /[ $(){}[\]&|;<>!"'`*?#~]/;
-const SINGLE_QUOTE_PATTERN = /'/g;
-
-// Parse and escape file paths to handle special characters
-export const parseFilePaths = (files: string[]): string[] =>
-  files.map((file) => {
-    // Check if the path needs escaping (contains special shell characters)
-    if (SPECIAL_CHARS_PATTERN.test(file)) {
-      // Escape single quotes by replacing ' with '\'' and wrap in single quotes
-      return `'${file.replace(SINGLE_QUOTE_PATTERN, "'\\''")}' `;
-    }
-    return file;
-  });
+// Parse file paths passed to child_process arg arrays.
+// We intentionally avoid shell escaping because commands are executed
+// without a shell to prevent DEP0190 warnings on newer Node.js versions.
+export const parseFilePaths = (files: string[]): string[] => files;
 
 export const ensureDirectory = async (path: string) => {
   const dir = dirname(path);


### PR DESCRIPTION
## Summary
- replace `spawnSync(..., { shell: true })` command execution paths in `check`, `fix`, and `doctor` with direct process execution
- add Windows fallback behavior that retries with `.cmd` only when the base executable is missing (`ENOENT`)
- remove shell-style file path escaping in `parseFilePaths` since args are now passed directly without a shell
- add regression tests for Windows `.cmd` fallback and updated file path behavior

## Why
Node 22.12+ emits DEP0190 warnings when passing arg arrays with `shell: true`. This change removes those warnings while preserving Windows compatibility.

## Verification
- `bun test __tests__/check.test.ts __tests__/fix.test.ts __tests__/doctor.test.ts __tests__/utils.test.ts` in `packages/cli`
- linked local CLI into `ultracite-test-app` and ran:
  - `bun run check`
  - `bun run fix`
- both commands complete without DEP0190 warnings

Fixes #611