### PR TITLE
Remove CSS formatter overrides to enable global configuration inheritance

### DIFF
--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -473,6 +473,7 @@
   },
   "javascript": {
     "formatter": {
+      "enabled": true,
       "arrowParentheses": "always",
       "bracketSameLine": false,
       "jsxQuoteStyle": "double",
@@ -484,8 +485,6 @@
   "css": {
     "formatter": {
       "enabled": true,
-      "lineEnding": "lf",
-      "lineWidth": 80,
       "quoteStyle": "double"
     },
     "parser": {


### PR DESCRIPTION
## Description

The objective of this is to allow the CSS formatting to inherit directly from the global Biome settings. Currently, certain properties within the CSS formatter block override global preferences (for instance, when a user defines a global `lineWidth` of 120, the CSS formatter remains locked at 80).

## Changes

To achieve this, the Biome configuration must be modified to remove the following lines in the `css.formatter` section.
Additionally, `"enabled": true` was added to the `javascript.formatter` section as it appeared to be missing.

```
{
  "javascript": {
    "formatter": {
      "enabled": true     // added property
    }
  },
  "css": {
    "formatter": {
      "lineEnding": "lf", // line to be removed
      "lineWidth": 80     // line to be removed
    }
  }
}
```


By removing these overrides, the CSS formatter will default to the configuration defined in the top-level `formatter` block. This ensures that changes to properties like `lineWidth` or `lineEnding` are applied uniformly across all supported languages, including CSS.

## Expected Outcome

Users will be able to manage project-wide formatting standards from a single global configuration block, eliminating the need to redefine them specifically for CSS.

## Related Issues

<!-- Closes #<issue_number> -->

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
