### PR TITLE
fix(oxlint/vitest): disable prefer-called-times to resolve conflict with prefer-called-once

### DIFF
--- a/.changeset/fix-prefer-called-times-conflict.md
+++ b/.changeset/fix-prefer-called-times-conflict.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Disable conflicting `vitest/prefer-called-times` oxlint rule to resolve conflict with `vitest/prefer-called-once`

--- a/packages/cli/__tests__/oxlint-config.test.ts
+++ b/packages/cli/__tests__/oxlint-config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+/**
+ * Oxlint config rule conflict tests
+ *
+ * These tests validate that mutually exclusive rules in oxlint configs are
+ * not both enabled simultaneously. When two rules conflict, one must be
+ * explicitly disabled.
+ */
+import { join } from "node:path";
+
+const stripJsonComments = (content: string): string =>
+  content
+    .replaceAll(/\/\*[\s\S]*?\*\//g, "")
+    .replaceAll(/\/\/.*$/gm, "")
+    .replaceAll(/,(\s*[}\]])/g, "$1");
+
+const readOxlintConfig = async (name: string) => {
+  const configPath = join(
+    import.meta.dirname,
+    `../config/oxlint/${name}/.oxlintrc.json`
+  );
+  // Use Bun.file to avoid node:fs/promises mocks from other test files
+  const content = await Bun.file(configPath).text();
+  return JSON.parse(stripJsonComments(content));
+};
+
+const isEnabled = (rule: unknown) => rule === "error" || rule === "warn";
+
+describe("oxlint vitest config", () => {
+  /**
+   * prefer-called-once vs prefer-called-times
+   *
+   * These two rules are mutually exclusive and enforce opposite styles:
+   * - prefer-called-once: enforce toHaveBeenCalledOnce() over toHaveBeenCalledTimes(1)
+   * - prefer-called-times: enforce toHaveBeenCalledTimes(1) over toHaveBeenCalledOnce()
+   *
+   * Enabling both causes an unfixable conflict: any valid code would trigger one of
+   * the two rules simultaneously. The ESLint vitest config resolves this by disabling
+   * prefer-called-times (see packages/cli/config/eslint/vitest/rules/vitest.mjs).
+   * The oxlint vitest config must be consistent.
+   */
+  describe("prefer-called-once vs prefer-called-times conflict", () => {
+    test("prefer-called-times is explicitly disabled to avoid conflict with prefer-called-once", async () => {
+      const config = await readOxlintConfig("vitest");
+      const rules = config.overrides?.[0]?.rules ?? {};
+
+      // prefer-called-times must be "off" — it directly contradicts prefer-called-once
+      expect(rules["vitest/prefer-called-times"]).toBe("off");
+    });
+
+    test("prefer-called-once and prefer-called-times are not both enabled", async () => {
+      const config = await readOxlintConfig("vitest");
+      const rules = config.overrides?.[0]?.rules ?? {};
+
+      const calledOnceEnabled = isEnabled(rules["vitest/prefer-called-once"]);
+      const calledTimesEnabled = isEnabled(rules["vitest/prefer-called-times"]);
+
+      expect(
+        calledOnceEnabled && calledTimesEnabled,
+        "prefer-called-once and prefer-called-times are both enabled — they conflict: one enforces toHaveBeenCalledOnce(), the other enforces toHaveBeenCalledTimes(1)"
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/cli/config/oxlint/vitest/.oxlintrc.json
+++ b/packages/cli/config/oxlint/vitest/.oxlintrc.json
@@ -35,6 +35,11 @@
         "vitest/no-test-prefixes": "error",
         "vitest/no-test-return-statement": "error",
         "vitest/prefer-called-with": "error",
+        // Disabled: conflicts with prefer-called-once — both rules enforce opposite styles
+        // prefer-called-times: use toHaveBeenCalledTimes(1) instead of toHaveBeenCalledOnce()
+        // prefer-called-once: use toHaveBeenCalledOnce() instead of toHaveBeenCalledTimes(1)
+        // Consistent with ESLint vitest config (packages/cli/config/eslint/vitest/rules/vitest.mjs)
+        "vitest/prefer-called-times": "off",
         "vitest/prefer-comparison-matcher": "error",
         "vitest/prefer-each": "error",
         "vitest/prefer-equality-matcher": "error",


### PR DESCRIPTION
## Description

Resolves a rule conflict in the oxlint vitest configuration between `vitest/prefer-called-once` and `vitest/prefer-called-times`. These two rules enforce opposite styles:

- `prefer-called-once` — enforce `toHaveBeenCalledOnce()` over `toHaveBeenCalledTimes(1)`
- `prefer-called-times` — enforce `toHaveBeenCalledTimes(1)` over `toHaveBeenCalledOnce()`

When both are active simultaneously (via plugin-level defaults), any call assertion triggers one rule or the other — creating an unfixable lint error. The fix explicitly disables `vitest/prefer-called-times` in the oxlint vitest config, consistent with the existing ESLint vitest config decision. A config validation test is added to prevent the conflict from being re-introduced.

## Related Issues

Closes #604

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

The ESLint vitest config already resolved this same conflict in the same direction (`vitest/prefer-called-times` is `"off"` with the comment "Conflicts with prefer-called-once"). This PR brings the oxlint config in line with that decision.
