### PR TITLE
Fix oxlint and oxfmt TypeScript exports

### DIFF
--- a/.changeset/fair-emus-rule.md
+++ b/.changeset/fair-emus-rule.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Add declaration files for `ultracite/oxlint/*` and `ultracite/oxfmt` so TypeScript config imports resolve without `ts(7016)` errors.

--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ $RECYCLE.BIN/
 
 # Next.js
 next-env.d.ts
+
+# Generated config declaration files
+packages/cli/config/oxlint/*/index.d.mts
+packages/cli/config/oxfmt/index.d.mts

--- a/packages/cli/__tests__/oxlint-config.test.ts
+++ b/packages/cli/__tests__/oxlint-config.test.ts
@@ -54,7 +54,7 @@ describe("oxlint package exports", () => {
       join(import.meta.dirname, "../config/oxfmt")
     );
 
-    expect(oxfmtFiles.includes("index.d.mts")).toBe(true);
+    expect(oxfmtFiles).toContain("index.d.mts");
   });
 });
 

--- a/packages/cli/__tests__/oxlint-config.test.ts
+++ b/packages/cli/__tests__/oxlint-config.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, test } from "bun:test";
  * not both enabled simultaneously. When two rules conflict, one must be
  * explicitly disabled.
  */
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
+
+import packageJson from "../package.json";
 
 const readOxlintConfig = async (name: string) => {
   const configPath = join(import.meta.dirname, `../config/oxlint/${name}`);
@@ -15,6 +18,45 @@ const readOxlintConfig = async (name: string) => {
 };
 
 const isEnabled = (rule: unknown) => rule === "error" || rule === "warn";
+
+describe("oxlint package exports", () => {
+  test("publishes typed oxlint subpath exports", () => {
+    expect(packageJson.exports["./oxlint/*"]).toEqual({
+      default: "./config/oxlint/*/index.mjs",
+      types: "./config/oxlint/*/index.d.mts",
+    });
+  });
+
+  test("ships declaration files for each oxlint config", () => {
+    const oxlintConfigDirectory = join(import.meta.dirname, "../config/oxlint");
+    const configs = readdirSync(oxlintConfigDirectory, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .toSorted();
+
+    const typedConfigs = configs.filter((config) => {
+      const configFiles = readdirSync(join(oxlintConfigDirectory, config));
+      return configFiles.includes("index.d.mts");
+    });
+
+    expect(typedConfigs).toEqual(configs);
+  });
+
+  test("publishes typed oxfmt export", () => {
+    expect(packageJson.exports["./oxfmt"]).toEqual({
+      default: "./config/oxfmt/index.mjs",
+      types: "./config/oxfmt/index.d.mts",
+    });
+  });
+
+  test("ships oxfmt declaration file", () => {
+    const oxfmtFiles = readdirSync(
+      join(import.meta.dirname, "../config/oxfmt")
+    );
+
+    expect(oxfmtFiles.includes("index.d.mts")).toBe(true);
+  });
+});
 
 describe("oxlint vitest config", () => {
   /**

--- a/packages/cli/config/oxfmt/index.d.mts
+++ b/packages/cli/config/oxfmt/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxfmtConfig } from "oxfmt";
+
+declare const config: OxfmtConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/angular/index.d.mts
+++ b/packages/cli/config/oxlint/angular/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/astro/index.d.mts
+++ b/packages/cli/config/oxlint/astro/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/core/index.d.mts
+++ b/packages/cli/config/oxlint/core/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/jest/index.d.mts
+++ b/packages/cli/config/oxlint/jest/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/nestjs/index.d.mts
+++ b/packages/cli/config/oxlint/nestjs/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/next/index.d.mts
+++ b/packages/cli/config/oxlint/next/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/qwik/index.d.mts
+++ b/packages/cli/config/oxlint/qwik/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/react/index.d.mts
+++ b/packages/cli/config/oxlint/react/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/remix/index.d.mts
+++ b/packages/cli/config/oxlint/remix/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/solid/index.d.mts
+++ b/packages/cli/config/oxlint/solid/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/svelte/index.d.mts
+++ b/packages/cli/config/oxlint/svelte/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/vitest/index.d.mts
+++ b/packages/cli/config/oxlint/vitest/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/config/oxlint/vue/index.d.mts
+++ b/packages/cli/config/oxlint/vue/index.d.mts
@@ -1,0 +1,5 @@
+import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
+    "prebuild": "bun run scripts/generate-dts.ts",
     "build": "tsup",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
@@ -108,9 +109,13 @@
     "tsup": "^8.5.1"
   },
   "peerDependencies": {
+    "oxfmt": ">=0.1.0",
     "oxlint": "^1.0.0"
   },
   "peerDependenciesMeta": {
+    "oxfmt": {
+      "optional": true
+    },
     "oxlint": {
       "optional": true
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,8 +31,14 @@
   "exports": {
     "./biome/*": "./config/biome/*/biome.jsonc",
     "./eslint/*": "./config/eslint/*/eslint.config.mjs",
-    "./oxlint/*": "./config/oxlint/*/index.mjs",
-    "./oxfmt": "./config/oxfmt/index.mjs",
+    "./oxlint/*": {
+      "types": "./config/oxlint/*/index.d.mts",
+      "default": "./config/oxlint/*/index.mjs"
+    },
+    "./oxfmt": {
+      "types": "./config/oxfmt/index.d.mts",
+      "default": "./config/oxfmt/index.mjs"
+    },
     "./prettier": "./config/prettier/prettier.config.mjs",
     "./stylelint": "./config/stylelint/stylelint.config.mjs",
     "./*": "./config/biome/*/biome.jsonc"

--- a/packages/cli/scripts/generate-dts.ts
+++ b/packages/cli/scripts/generate-dts.ts
@@ -1,0 +1,43 @@
+/**
+ * Generates declaration files (.d.mts) for oxlint and oxfmt config exports.
+ * Run as part of the build to keep types in sync with config directories.
+ */
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const configDir = join(import.meta.dirname, "../config");
+
+const oxlintDeclaration = `import type { OxlintConfig } from "oxlint";
+
+declare const config: OxlintConfig;
+
+export default config;
+`;
+
+const oxfmtDeclaration = `import type { OxfmtConfig } from "oxfmt";
+
+declare const config: OxfmtConfig;
+
+export default config;
+`;
+
+// Generate oxlint declarations
+const oxlintDir = join(configDir, "oxlint");
+const configs = readdirSync(oxlintDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+for (const config of configs) {
+  const dir = join(oxlintDir, config);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "index.d.mts"), oxlintDeclaration);
+}
+
+// Generate oxfmt declaration
+const oxfmtDir = join(configDir, "oxfmt");
+mkdirSync(oxfmtDir, { recursive: true });
+writeFileSync(join(oxfmtDir, "index.d.mts"), oxfmtDeclaration);
+
+console.log(
+  `Generated declaration files for ${String(configs.length)} oxlint configs and oxfmt`
+);


### PR DESCRIPTION
## Summary
- fix missing TypeScript declaration files for `ultracite/oxfmt` and `ultracite/oxlint/*`, which were causing `TS7016` errors in `oxfmt.config.ts` and `oxlint.config.ts` files
- add typed package exports for `ultracite/oxlint/*` and `ultracite/oxfmt`
- ship declaration files for the published oxlint and oxfmt config entrypoints
- add regression tests and a changeset to cover the packaging fix

## Verification
- `bun test`
- `bun run build`
- `bun run check-types`
- verified in a consumer project that `oxlint.config.ts` and `oxfmt.config.ts` no longer report `ts(7016)` for `ultracite/oxlint/*` and `ultracite/oxfmt`