### PR TITLE
fix: skip init skill prompt when skill already exists

### DIFF
--- a/.changeset/slow-lions-draw.md
+++ b/.changeset/slow-lions-draw.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Skip the init skill-install prompt when the Ultracite skill is already installed in the current project or globally.

--- a/packages/cli/__tests__/initialize.test.ts
+++ b/packages/cli/__tests__/initialize.test.ts
@@ -40,12 +40,20 @@ mock.module("node:child_process", () => ({
   spawnSync: mock(() => ({ status: 0 })),
 }));
 
+mock.module("cross-spawn", () => ({
+  sync: mock(() => ({ status: 0, stdout: "[]" })),
+}));
+
 mock.module("nypm", () => ({
   addDevDependency: mock(() => Promise.resolve()),
   detectPackageManager: mock(() =>
     Promise.resolve({ name: "npm", warnings: [] })
   ),
-  dlxCommand: mock(() => "npx ultracite fix"),
+  dlxCommand: mock((_pm: string, pkg: string, options?: { args?: string[] }) =>
+    pkg === "skills"
+      ? `npx skills ${options?.args?.join(" ") ?? ""}`.trim()
+      : "npx ultracite fix"
+  ),
   removeDependency: mock(() => Promise.resolve()),
 }));
 
@@ -808,6 +816,199 @@ describe("initialize", () => {
           }),
         ],
       })
+    );
+  });
+
+  test("skips the skill prompt when the Ultracite skill is installed globally", async () => {
+    const mockInfo = mock(noop);
+    const mockSelect = mock(() => Promise.resolve("skip"));
+    const mockSpawn = mock((_command: string, args: string[]) => {
+      if (args[1] === "list" && !args.includes("-g")) {
+        return { status: 0, stdout: "[]" };
+      }
+
+      if (args[1] === "list" && args.includes("-g")) {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              agents: ["Claude Code"],
+              name: "ultracite",
+              path: "/Users/test/.claude/skills/ultracite",
+              scope: "global",
+            },
+          ]),
+        };
+      }
+
+      return { status: 0, stdout: "[]" };
+    });
+
+    mock.module("cross-spawn", () => ({
+      sync: mockSpawn,
+    }));
+
+    mock.module("nypm", () => ({
+      addDevDependency: mock(() => Promise.resolve()),
+      detectPackageManager: mock(() =>
+        Promise.resolve({ name: "npm", warnings: [] })
+      ),
+      dlxCommand: mock(
+        (_pm: string, pkg: string, options?: { args?: string[] }) =>
+          pkg === "skills"
+            ? `npx skills ${options?.args?.join(" ") ?? ""}`.trim()
+            : "npx ultracite fix"
+      ),
+      removeDependency: mock(() => Promise.resolve()),
+    }));
+
+    mock.module("@clack/prompts", () => ({
+      cancel: mock(noop),
+      intro: mock(noop),
+      isCancel: mock(() => false),
+      log: {
+        error: mock(noop),
+        info: mockInfo,
+        success: mock(noop),
+        warn: mock(noop),
+      },
+      multiselect: mock(() => Promise.resolve([])),
+      outro: mock(noop),
+      select: mockSelect,
+      spinner: mock(() => ({
+        message: mock(noop),
+        start: mock(noop),
+        stop: mock(noop),
+      })),
+    }));
+
+    await initialize({
+      agents: [],
+      editors: [],
+      frameworks: [],
+      hooks: [],
+      integrations: [],
+      linter: "biome",
+      pm: "npm",
+      skipInstall: true,
+    });
+
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npx",
+      ["skills", "list", "--json"],
+      expect.objectContaining({
+        encoding: "utf-8",
+        shell: false,
+        stdio: "pipe",
+      })
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npx",
+      ["skills", "list", "-g", "--json"],
+      expect.objectContaining({
+        encoding: "utf-8",
+        shell: false,
+        stdio: "pipe",
+      })
+    );
+    expect(mockSpawn).not.toHaveBeenCalledWith(
+      "npx",
+      ["skills", "add", "haydenbleasel/ultracite"],
+      expect.anything()
+    );
+    expect(mockInfo).not.toHaveBeenCalledWith(
+      expect.stringContaining("You can install the Ultracite skill later")
+    );
+  });
+
+  test("skips the skill prompt when the Ultracite skill is installed locally", async () => {
+    const mockInfo = mock(noop);
+    const mockSelect = mock(() => Promise.resolve("skip"));
+    const mockSpawn = mock((_command: string, args: string[]) => {
+      if (args[1] === "list" && !args.includes("-g")) {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              agents: ["Claude Code"],
+              name: "ultracite",
+              path: "/repo/.claude/skills/ultracite",
+              scope: "project",
+            },
+          ]),
+        };
+      }
+
+      return { status: 0, stdout: "[]" };
+    });
+
+    mock.module("cross-spawn", () => ({
+      sync: mockSpawn,
+    }));
+
+    mock.module("nypm", () => ({
+      addDevDependency: mock(() => Promise.resolve()),
+      detectPackageManager: mock(() =>
+        Promise.resolve({ name: "npm", warnings: [] })
+      ),
+      dlxCommand: mock(
+        (_pm: string, pkg: string, options?: { args?: string[] }) =>
+          pkg === "skills"
+            ? `npx skills ${options?.args?.join(" ") ?? ""}`.trim()
+            : "npx ultracite fix"
+      ),
+      removeDependency: mock(() => Promise.resolve()),
+    }));
+
+    mock.module("@clack/prompts", () => ({
+      cancel: mock(noop),
+      intro: mock(noop),
+      isCancel: mock(() => false),
+      log: {
+        error: mock(noop),
+        info: mockInfo,
+        success: mock(noop),
+        warn: mock(noop),
+      },
+      multiselect: mock(() => Promise.resolve([])),
+      outro: mock(noop),
+      select: mockSelect,
+      spinner: mock(() => ({
+        message: mock(noop),
+        start: mock(noop),
+        stop: mock(noop),
+      })),
+    }));
+
+    await initialize({
+      agents: [],
+      editors: [],
+      frameworks: [],
+      hooks: [],
+      integrations: [],
+      linter: "biome",
+      pm: "npm",
+      skipInstall: true,
+    });
+
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npx",
+      ["skills", "list", "--json"],
+      expect.objectContaining({
+        encoding: "utf-8",
+        shell: false,
+        stdio: "pipe",
+      })
+    );
+    expect(mockSpawn).not.toHaveBeenCalledWith(
+      "npx",
+      ["skills", "list", "-g", "--json"],
+      expect.anything()
+    );
+    expect(mockInfo).not.toHaveBeenCalledWith(
+      expect.stringContaining("You can install the Ultracite skill later")
     );
   });
 

--- a/packages/cli/src/initialize.ts
+++ b/packages/cli/src/initialize.ts
@@ -1087,13 +1087,13 @@ export const initialize = async (flags?: InitializeFlags) => {
       log.success("Successfully initialized Ultracite!");
     }
 
-    const didInstallSkill = await maybeInstallUltraciteSkill({
+    const hasUltraciteSkill = await maybeInstallUltraciteSkill({
       packageManager: pm,
       quiet,
       shouldInstall: opts.installSkill,
     });
 
-    if (!quiet && !didInstallSkill) {
+    if (!quiet && !hasUltraciteSkill) {
       log.info(
         `You can install the Ultracite skill later with \`${getUltraciteSkillInstallCommand(pm)}\`.`
       );

--- a/packages/cli/src/skill.ts
+++ b/packages/cli/src/skill.ts
@@ -5,6 +5,7 @@ import type { PackageManagerName } from "nypm";
 import { runCommandSync } from "./run-command";
 
 const ultraciteSkillRepo = "haydenbleasel/ultracite";
+const ultraciteSkillName = "ultracite";
 
 interface MaybeInstallUltraciteSkillOptions {
   packageManager: PackageManagerName;
@@ -19,6 +20,49 @@ const buildUltraciteSkillInstallCommand = (
     args: ["add", ultraciteSkillRepo],
     short: packageManager === "npm",
   });
+
+const buildUltraciteSkillListCommand = (
+  packageManager: PackageManagerName,
+  global = false
+) =>
+  dlxCommand(packageManager, "skills", {
+    args: global ? ["list", "-g", "--json"] : ["list", "--json"],
+    short: packageManager === "npm",
+  });
+
+const isUltraciteSkillInstalledInScope = (
+  packageManager: PackageManagerName,
+  global = false
+) => {
+  const fullCommand = buildUltraciteSkillListCommand(packageManager, global);
+  const [command, ...args] = fullCommand.split(" ");
+  const result = runCommandSync(command, args, {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  if (result.error || result.status !== 0 || !result.stdout) {
+    return false;
+  }
+
+  try {
+    const installedSkills = JSON.parse(
+      typeof result.stdout === "string"
+        ? result.stdout
+        : result.stdout.toString("utf-8")
+    ) as {
+      name?: string;
+    }[];
+
+    return installedSkills.some((skill) => skill.name === ultraciteSkillName);
+  } catch {
+    return false;
+  }
+};
+
+const hasUltraciteSkillInstalled = (packageManager: PackageManagerName) =>
+  isUltraciteSkillInstalledInScope(packageManager) ||
+  isUltraciteSkillInstalledInScope(packageManager, true);
 
 const promptToInstallUltraciteSkill = async () => {
   const installSkillResult = await select({
@@ -47,6 +91,14 @@ export const maybeInstallUltraciteSkill = async ({
   quiet = false,
   shouldInstall,
 }: MaybeInstallUltraciteSkillOptions) => {
+  if (
+    shouldInstall === undefined &&
+    !quiet &&
+    hasUltraciteSkillInstalled(packageManager)
+  ) {
+    return true;
+  }
+
   const wantsInstall =
     shouldInstall ?? (!quiet && (await promptToInstallUltraciteSkill()));
 


### PR DESCRIPTION
## Description

This fixes a small paper cut in ultracite init. The CLI was still asking whether to install the Ultracite skill even when that skill was already present. It now checks both project and global skill installs before showing the prompt, and the init tests cover both cases.

## Related Issues

Closes #671

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A

## Additional Notes

I ran these locally before opening the PR:
- `bun run check-types`
- `bun check`
- `bun test`
- Tested impl locally


---
<details>
<summary>Local impl test:</summary>

```sh
~\mynameistito\temp mkdir -p ultrac

        Directory: C:\Users\mynameistito\temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d----        16/04/2026     08:11                  ultrac

~\mynameistito\temp cd ultrac
~\mynameistito\temp\ultrac bun init

✓ Select a project template: Blank

 + .gitignore
 + index.ts
 + tsconfig.json (for editor autocomplete)
 + README.md

To get started, run:

    bun run index.ts


~\mynameistito\temp\ultrac
~\mynameistito\temp\ultrac bun link ultracite
bun link v1.3.12 (700fc117)

installed ultracite@link:ultracite with binaries:
 - ultracite

1 package installed [9.00ms]
~\mynameistito\temp\ultrac zed .
~\mynameistito\temp\ultrac ultracite init
┌  Ultracite v7.5.9 Initialization
│
●  Detected lockfile, using bun
│
◇  Which linter do you want to use?
│  Biome (Recommended)
│
◇  Which frameworks are you using (optional)?
│  none
│
◇  Which editors do you want to configure (recommended)?
│  none
│
◇  Which agent files do you want to add (optional)?
│  none
│
◇  Which agent hooks do you want to enable (optional)?
│  none
│
◇  Would you like any of the following (optional)?
│  none
│
◇  Dependencies installed.
│
◇  tsconfig.json files updated.
│
◇  Biome configuration created.
│
◆  Successfully initialized Ultracite!
```

</details>

