### PR TITLE
fix(ci): add Node.js 22.x setup to check job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -95,6 +95,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+
       - uses: oven-sh/setup-bun@v2
         name: Install Bun
 


### PR DESCRIPTION
## Description

The `check` CI job had no explicit Node.js setup, so it fell back to the runner's default (Node 20.20.2). When `bun run check` runs, oxfmt tries to load `oxfmt.config.ts` using Node.js — but Node 20 requires the `--experimental-strip-types` flag to handle `.ts` files natively, which isn't set. Node 22.12+ supports TypeScript stripping without extra flags.

This adds `actions/setup-node@v6` with `node-version: 22.x` to the `check` job, matching what the `build` and `test` jobs already do for their `node-22` matrix entries.

## Related Issues

Fixes the failure in https://github.com/haydenbleasel/ultracite/actions/runs/24475609453/job/71526855203

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary