### PR TITLE
fix: migrate all legacy biome/x extends - rm old

### DIFF
--- a/.changeset/fix-legacy-biome-core-extends.md
+++ b/.changeset/fix-legacy-biome-core-extends.md
@@ -2,4 +2,4 @@
 "ultracite": patch
 ---
 
-Fix `update` command not removing legacy `ultracite/core` extends entry when migrating to `ultracite/biome/core`.
+Fix `update` command not migrating legacy `ultracite/<name>` extends entries to `ultracite/biome/<name>` (e.g. `ultracite/core`, `ultracite/react`, `ultracite/type-aware`, etc.).

--- a/.changeset/fix-legacy-biome-core-extends.md
+++ b/.changeset/fix-legacy-biome-core-extends.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Fix `update` command not removing legacy `ultracite/core` extends entry when migrating to `ultracite/biome/core`.

--- a/packages/cli/__tests__/biome.test.ts
+++ b/packages/cli/__tests__/biome.test.ts
@@ -381,6 +381,47 @@ describe("biome", () => {
       ]);
     });
 
+    test("dedupes when both legacy and new forms coexist", async () => {
+      const mockWriteFile = mock((_path: string, _content: string) =>
+        Promise.resolve()
+      );
+      mock.module("node:fs/promises", () => ({
+        access: mock((path: string) => {
+          if (path === "./biome.jsonc") {
+            return Promise.resolve();
+          }
+          return Promise.reject(new Error("ENOENT"));
+        }),
+        readFile: mock(() =>
+          Promise.resolve(
+            '{"extends": ["ultracite/core", "ultracite/biome/core", "ultracite/react"]}'
+          )
+        ),
+        writeFile: mockWriteFile,
+      }));
+
+      mock.module("node:fs", () => ({
+        accessSync: mock((path: string) => {
+          if (path === "./biome.jsonc") {
+            return;
+          }
+          throw new Error("ENOENT");
+        }),
+        existsSync: mock(() => false),
+        readFileSync: mock(() => "{}"),
+      }));
+
+      await biome.update();
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      const [writeCall] = mockWriteFile.mock.calls;
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.extends).toEqual([
+        "ultracite/biome/core",
+        "ultracite/biome/react",
+      ]);
+    });
+
     test("handles invalid JSON gracefully", async () => {
       const mockWriteFile = mock((_path: string, _content: string) =>
         Promise.resolve()

--- a/packages/cli/__tests__/biome.test.ts
+++ b/packages/cli/__tests__/biome.test.ts
@@ -298,6 +298,43 @@ describe("biome", () => {
       ]);
     });
 
+    test("replaces legacy ultracite/core with ultracite/biome/core", async () => {
+      const mockWriteFile = mock((_path: string, _content: string) =>
+        Promise.resolve()
+      );
+      mock.module("node:fs/promises", () => ({
+        access: mock((path: string) => {
+          if (path === "./biome.jsonc") {
+            return Promise.resolve();
+          }
+          return Promise.reject(new Error("ENOENT"));
+        }),
+        readFile: mock(() =>
+          Promise.resolve('{"extends": ["ultracite/core"]}')
+        ),
+        writeFile: mockWriteFile,
+      }));
+
+      mock.module("node:fs", () => ({
+        accessSync: mock((path: string) => {
+          if (path === "./biome.jsonc") {
+            return;
+          }
+          throw new Error("ENOENT");
+        }),
+        existsSync: mock(() => false),
+        readFileSync: mock(() => "{}"),
+      }));
+
+      await biome.update();
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      const [writeCall] = mockWriteFile.mock.calls;
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.extends).toEqual(["ultracite/biome/core"]);
+      expect(writtenContent.extends).not.toContain("ultracite/core");
+    });
+
     test("handles invalid JSON gracefully", async () => {
       const mockWriteFile = mock((_path: string, _content: string) =>
         Promise.resolve()

--- a/packages/cli/__tests__/biome.test.ts
+++ b/packages/cli/__tests__/biome.test.ts
@@ -298,7 +298,7 @@ describe("biome", () => {
       ]);
     });
 
-    test("replaces legacy ultracite/core with ultracite/biome/core", async () => {
+    test("migrates all legacy ultracite/<name> entries to ultracite/biome/<name>", async () => {
       const mockWriteFile = mock((_path: string, _content: string) =>
         Promise.resolve()
       );
@@ -310,7 +310,9 @@ describe("biome", () => {
           return Promise.reject(new Error("ENOENT"));
         }),
         readFile: mock(() =>
-          Promise.resolve('{"extends": ["ultracite/core"]}')
+          Promise.resolve(
+            '{"extends": ["ultracite/core", "ultracite/react", "ultracite/type-aware"]}'
+          )
         ),
         writeFile: mockWriteFile,
       }));
@@ -331,8 +333,52 @@ describe("biome", () => {
       expect(mockWriteFile).toHaveBeenCalled();
       const [writeCall] = mockWriteFile.mock.calls;
       const writtenContent = JSON.parse(writeCall[1] as string);
-      expect(writtenContent.extends).toEqual(["ultracite/biome/core"]);
-      expect(writtenContent.extends).not.toContain("ultracite/core");
+      expect(writtenContent.extends).toEqual([
+        "ultracite/biome/core",
+        "ultracite/biome/react",
+        "ultracite/biome/type-aware",
+      ]);
+    });
+
+    test("does not remap already-correct ultracite/biome/* entries", async () => {
+      const mockWriteFile = mock((_path: string, _content: string) =>
+        Promise.resolve()
+      );
+      mock.module("node:fs/promises", () => ({
+        access: mock((path: string) => {
+          if (path === "./biome.jsonc") {
+            return Promise.resolve();
+          }
+          return Promise.reject(new Error("ENOENT"));
+        }),
+        readFile: mock(() =>
+          Promise.resolve(
+            '{"extends": ["ultracite/biome/core", "ultracite/biome/react"]}'
+          )
+        ),
+        writeFile: mockWriteFile,
+      }));
+
+      mock.module("node:fs", () => ({
+        accessSync: mock((path: string) => {
+          if (path === "./biome.jsonc") {
+            return;
+          }
+          throw new Error("ENOENT");
+        }),
+        existsSync: mock(() => false),
+        readFileSync: mock(() => "{}"),
+      }));
+
+      await biome.update();
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      const [writeCall] = mockWriteFile.mock.calls;
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.extends).toEqual([
+        "ultracite/biome/core",
+        "ultracite/biome/react",
+      ]);
     });
 
     test("handles invalid JSON gracefully", async () => {

--- a/packages/cli/src/linters/biome.ts
+++ b/packages/cli/src/linters/biome.ts
@@ -64,7 +64,10 @@ export const biome = {
     // Check if ultracite is already in the extends array
     const existingExtends = configToWork.extends ?? [];
 
-    const newExtends = [...existingExtends];
+    // Remove legacy ultracite/core entry and replace with ultracite/biome/core
+    const newExtends = existingExtends.filter(
+      (ext) => ext !== "ultracite/core"
+    );
 
     // Add ultracite/biome/core if not present
     if (!newExtends.includes("ultracite/biome/core")) {

--- a/packages/cli/src/linters/biome.ts
+++ b/packages/cli/src/linters/biome.ts
@@ -64,10 +64,11 @@ export const biome = {
     // Check if ultracite is already in the extends array
     const existingExtends = configToWork.extends ?? [];
 
-    // Remove legacy ultracite/core entry and replace with ultracite/biome/core
-    const newExtends = existingExtends.filter(
-      (ext) => ext !== "ultracite/core"
-    );
+    // Migrate legacy ultracite/<name> entries to ultracite/biome/<name>
+    const newExtends = existingExtends.map((ext) => {
+      const legacyMatch = /^ultracite\/(?!biome\/)(.+)$/.exec(ext);
+      return legacyMatch ? `ultracite/biome/${legacyMatch[1]}` : ext;
+    });
 
     // Add ultracite/biome/core if not present
     if (!newExtends.includes("ultracite/biome/core")) {

--- a/packages/cli/src/linters/biome.ts
+++ b/packages/cli/src/linters/biome.ts
@@ -11,6 +11,8 @@ const defaultConfig = {
   extends: ["ultracite/biome/core"],
 };
 
+const LEGACY_EXTEND_RE = /^ultracite\/(?!biome\/)(.+)$/;
+
 const getBiomeConfigPath = (): string => {
   // Check for biome.json first, then fall back to biome.jsonc
   if (exists("./biome.json")) {
@@ -64,11 +66,13 @@ export const biome = {
     // Check if ultracite is already in the extends array
     const existingExtends = configToWork.extends ?? [];
 
-    // Migrate legacy ultracite/<name> entries to ultracite/biome/<name>
-    const newExtends = existingExtends.map((ext) => {
-      const legacyMatch = /^ultracite\/(?!biome\/)(.+)$/.exec(ext);
+    // Migrate legacy ultracite/<name> entries to ultracite/biome/<name>,
+    // deduping in case both legacy and new forms coexist.
+    const remapped = existingExtends.map((ext) => {
+      const legacyMatch = LEGACY_EXTEND_RE.exec(ext);
       return legacyMatch ? `ultracite/biome/${legacyMatch[1]}` : ext;
     });
+    const newExtends = [...new Set(remapped)];
 
     // Add ultracite/biome/core if not present
     if (!newExtends.includes("ultracite/biome/core")) {


### PR DESCRIPTION
## Summary

- `biome.update()` was adding new `ultracite/biome/*` entries but never removing or remapping old `ultracite/<name>` entries (e.g. `ultracite/core`, `ultracite/react`, `ultracite/type-aware`, etc.), leaving both in the extends array
- Use a regex remap (`ultracite/<name>` → `ultracite/biome/<name>`) on the entire existing extends array, covering all biome configs — not just `core`
- Added tests for multi-entry migration and for verifying already-correct `ultracite/biome/*` entries are left untouched

Closes #683

## Test plan

- [x] Run `bun test packages/cli/__tests__/biome.test.ts` — all tests pass including new migration tests
- [x] Verify a `biome.jsonc` with legacy entries like `["ultracite/core", "ultracite/react"]` is updated to `["ultracite/biome/core", "ultracite/biome/react"]` after running the update path

🤖 Generated with [Claude Code](https://claude.com/claude-code)