### PR TITLE
Ignore worker-configuration.d.ts

### DIFF
--- a/.changeset/ignore-worker-configuration-dts.md
+++ b/.changeset/ignore-worker-configuration-dts.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Ignore Cloudflare Workers' generated `worker-configuration.d.ts` (produced by `wrangler types`), matching the existing handling of `next-env.d.ts`.

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -54,7 +54,8 @@
       "!!**/package-lock.json",
       "!!**/yarn.lock",
       "!!**/pnpm-lock.yaml",
-      "!!**/next-env.d.ts"
+      "!!**/next-env.d.ts",
+      "!!**/worker-configuration.d.ts"
     ]
   },
   "formatter": {

--- a/packages/cli/config/shared/ignores.mjs
+++ b/packages/cli/config/shared/ignores.mjs
@@ -63,4 +63,5 @@ export const ignorePatterns = [
 
   // ── Framework type definitions ────────────────────────────────────
   "**/next-env.d.ts",
+  "**/worker-configuration.d.ts",
 ];


### PR DESCRIPTION
## Summary
Fixes: #685 
- Add `**/worker-configuration.d.ts` to the shared ignore patterns
- Cloudflare Workers projects generate this file via `wrangler types` (analogous to Next.js's `next-env.d.ts`), so it should not be linted/formatted
- Prebuild script syncs the new entry into `biome/core`'s `files.includes`

## Test plan
- [x] `bun test` in `packages/cli` (356 pass)
- [x] `bun run types`
- [x] `bun run prebuild` regenerates biome.jsonc with the new ignore