### PR TITLE
Support -v as short alias for --version

### DIFF
--- a/.changeset/cli-short-version-flag.md
+++ b/.changeset/cli-short-version-flag.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Support `-v` as a short alias for `--version` on the CLI (previously only `-V` worked).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,7 +13,7 @@ const program = new Command();
 
 program
   .name("ultracite")
-  .version(packageJson.version)
+  .version(packageJson.version, "-v, --version")
   .description(packageJson.description);
 
 program


### PR DESCRIPTION
## Summary
Fixes: #683
- Pass explicit flags string to commander's `.version()` so `-v` works alongside `--version` (commander's default short flag is `-V`, which most users don't expect)

## Test plan
- [x] `node dist/index.js -v` → prints version
- [x] `node dist/index.js --version` → prints version
- [x] `bun test` (356 pass)