### PR TITLE
Add allowForLoopAfterthoughts to oxlint no-plusplus

### DIFF
--- a/.changeset/oxlint-no-plusplus-allow-for-loop.md
+++ b/.changeset/oxlint-no-plusplus-allow-for-loop.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Add `allowForLoopAfterthoughts` to oxlint `no-plusplus` for parity with the biome `noIncrementDecrement` config (#371). `i++` in `for` loop afterthoughts is now allowed; `++`/`--` elsewhere remains an error.

--- a/packages/cli/config/oxlint/core/index.mjs
+++ b/packages/cli/config/oxlint/core/index.mjs
@@ -138,7 +138,7 @@ export default defineConfig({
     "no-obj-calls": "error",
     "no-object-constructor": "error",
     "no-param-reassign": "error",
-    "no-plusplus": "error",
+    "no-plusplus": ["error", { allowForLoopAfterthoughts: true }],
     "no-promise-executor-return": "error",
     "no-proto": "error",
     "no-prototype-builtins": "error",


### PR DESCRIPTION
## Summary

Mirrors #371, which set the same option on biome's noIncrementDecrement. Without this, `for (let i = 0; i < n; i++)` fails lint, even though the biome side allows it.
