### PR TITLE
feat: support dot-prefixed Biome config files

### DIFF
--- a/.changeset/biome-dotfile-config.md
+++ b/.changeset/biome-dotfile-config.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Recognize `.biome.json` and `.biome.jsonc` as valid Biome config files across the CLI. `detectLinter`, the `doctor` command, and the Biome config resolver now match the dot-prefixed names alongside `biome.json`/`biome.jsonc`, following Biome's [documented configuration file resolution order](https://biomejs.dev/guides/configure-biome/#configuration-file-resolution). Closes #700.

--- a/packages/cli/__tests__/biome.test.ts
+++ b/packages/cli/__tests__/biome.test.ts
@@ -180,6 +180,34 @@ describe("biome", () => {
         "ultracite/biome/react",
       ]);
     });
+
+    test("resolves the .biome.json dotfile when present", async () => {
+      const mockWriteFile = mock((_path: string, _content: string) =>
+        Promise.resolve()
+      );
+      mock.module("node:fs/promises", () => ({
+        access: mock(() => Promise.reject(new Error("ENOENT"))),
+        readFile: mock(() => Promise.resolve("{}")),
+        writeFile: mockWriteFile,
+      }));
+
+      mock.module("node:fs", () => ({
+        accessSync: mock((path: string) => {
+          if (path === "./.biome.json") {
+            return;
+          }
+          throw new Error("ENOENT");
+        }),
+        existsSync: mock(() => false),
+        readFileSync: mock(() => "{}"),
+      }));
+
+      await biome.create();
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      const [writeCall] = mockWriteFile.mock.calls;
+      expect(writeCall[0]).toBe("./.biome.json");
+    });
   });
 
   describe("update", () => {

--- a/packages/cli/__tests__/detect-linter.test.ts
+++ b/packages/cli/__tests__/detect-linter.test.ts
@@ -84,6 +84,19 @@ describe("detectLinter", () => {
     expect(result).toBe("biome");
   });
 
+  test("returns biome when .biome.json exists in cwd", async () => {
+    const targetPath = join(cwd, ".biome.json");
+    mockAccess = mock((path: string) => {
+      if (path === targetPath) {
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const result = await realDetectLinter();
+    expect(result).toBe("biome");
+  });
+
   test("returns biome when .biome.jsonc exists in cwd", async () => {
     const targetPath = join(cwd, ".biome.jsonc");
     mockAccess = mock((path: string) => {

--- a/packages/cli/__tests__/detect-linter.test.ts
+++ b/packages/cli/__tests__/detect-linter.test.ts
@@ -18,7 +18,12 @@ const realExists = async (path: string) => {
   }
 };
 
-const biomeConfigNames = ["biome.json", "biome.jsonc"];
+const biomeConfigNames = [
+  "biome.json",
+  "biome.jsonc",
+  ".biome.json",
+  ".biome.jsonc",
+];
 const eslintConfigNames = [
   "eslint.config.mjs",
   "eslint.config.js",
@@ -68,6 +73,19 @@ const cwd = process.cwd();
 describe("detectLinter", () => {
   test("returns biome when biome.json exists in cwd", async () => {
     const targetPath = join(cwd, "biome.json");
+    mockAccess = mock((path: string) => {
+      if (path === targetPath) {
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const result = await realDetectLinter();
+    expect(result).toBe("biome");
+  });
+
+  test("returns biome when .biome.jsonc exists in cwd", async () => {
+    const targetPath = join(cwd, ".biome.jsonc");
     mockAccess = mock((path: string) => {
       if (path === targetPath) {
         return Promise.resolve();

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -65,6 +65,34 @@ describe("doctor", () => {
     consoleLogSpy.mockRestore();
   });
 
+  test("passes when biome is configured via a .biome.jsonc dotfile", () => {
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    mock.module("../src/utils", () => ({
+      detectLinter: () => "biome",
+    }));
+    mock.module("cross-spawn", () => ({
+      sync: mock(() => ({ status: 0, stdout: "1.0.0" })),
+    }));
+    mock.module("node:fs", () => ({
+      accessSync: mock(() => {}),
+      existsSync: mock((path: string) => {
+        const p = String(path);
+        return p.endsWith(".biome.jsonc") || p.endsWith("package.json");
+      }),
+      readFileSync: mock((path: string) => {
+        const p = String(path);
+        if (p.endsWith(".biome.jsonc")) {
+          return '{"extends": ["ultracite/biome/core"]}';
+        }
+        return '{"devDependencies": {"ultracite": "1.0.0"}}';
+      }),
+    }));
+
+    doctor();
+    consoleLogSpy.mockRestore();
+  });
+
   test("fails when biome is not installed", () => {
     mock.module("../src/utils", () => ({
       detectLinter: () => "biome",

--- a/packages/cli/benchmarks/cli.bench.ts
+++ b/packages/cli/benchmarks/cli.bench.ts
@@ -250,6 +250,10 @@ group("doctor", () => {
       mock.module("cross-spawn", () => ({
         sync: () => ({ status: 0, stderr: "", stdout: "1.0.0\n" }),
       }));
+      // detectLinter walks up the directory tree calling exists() at every
+      // ancestor, so its cost is filesystem- and machine-dependent. Stub it so
+      // this bench measures the doctor logic deterministically. doctor.ts only
+      // consumes detectLinter from ../utils, so replacing the module is safe.
       mock.module("../src/utils", () => ({
         detectLinter: () => "biome",
       }));

--- a/packages/cli/benchmarks/cli.bench.ts
+++ b/packages/cli/benchmarks/cli.bench.ts
@@ -250,6 +250,9 @@ group("doctor", () => {
       mock.module("cross-spawn", () => ({
         sync: () => ({ status: 0, stderr: "", stdout: "1.0.0\n" }),
       }));
+      mock.module("../src/utils", () => ({
+        detectLinter: () => "biome",
+      }));
       mock.module("@clack/prompts", () => ({
         intro: noop,
         log: {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -8,7 +8,7 @@ import { parse } from "jsonc-parser";
 import packageJson from "../../package.json" with { type: "json" };
 import { runCommandSync } from "../run-command";
 import { readPackageJsonSync } from "../schemas";
-import { detectLinter } from "../utils";
+import { biomeConfigNames, detectLinter } from "../utils";
 import type { Linter } from "../utils";
 
 interface DiagnosticCheck {
@@ -47,18 +47,10 @@ const checkToolInstallation = (
 // ---------------------------------------------------------------------------
 
 const checkBiomeConfig = (): DiagnosticCheck => {
-  // Biome supports configuration files, in the following order
-  const biomeConfigFiles = [
-    "biome.json",
-    "biome.jsonc",
-    ".biome.json",
-    ".biome.jsonc",
-  ];
-
   let configPath: string | null = null;
   let biomeConfigFile: string | null = null;
 
-  for (const fileName of biomeConfigFiles) {
+  for (const fileName of biomeConfigNames) {
     const fullPath = join(process.cwd(), fileName);
     if (existsSync(fullPath)) {
       configPath = fullPath;
@@ -69,7 +61,7 @@ const checkBiomeConfig = (): DiagnosticCheck => {
 
   if (!configPath) {
     return {
-      message: `No Biome config file found (expected one of: ${biomeConfigFiles.join(", ")})`,
+      message: `No Biome config file found (expected one of: ${biomeConfigNames.join(", ")})`,
       name: "Biome configuration",
       status: "fail",
     };

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -47,19 +47,29 @@ const checkToolInstallation = (
 // ---------------------------------------------------------------------------
 
 const checkBiomeConfig = (): DiagnosticCheck => {
-  const biomeConfigPath = join(process.cwd(), "biome.json");
-  const biomeJsoncPath = join(process.cwd(), "biome.jsonc");
+  // Biome supports configuration files, in the following order
+  const biomeConfigFiles = [
+    "biome.json",
+    "biome.jsonc",
+    ".biome.json",
+    ".biome.jsonc",
+  ];
 
   let configPath: string | null = null;
-  if (existsSync(biomeConfigPath)) {
-    configPath = biomeConfigPath;
-  } else if (existsSync(biomeJsoncPath)) {
-    configPath = biomeJsoncPath;
+  let biomeConfigFile: string | null = null;
+
+  for (const fileName of biomeConfigFiles) {
+    const fullPath = join(process.cwd(), fileName);
+    if (existsSync(fullPath)) {
+      configPath = fullPath;
+      biomeConfigFile = fileName;
+      break;
+    }
   }
 
   if (!configPath) {
     return {
-      message: "No biome.json or biome.jsonc file found",
+      message: `No Biome config file found (expected one of: ${biomeConfigFiles.join(", ")})`,
       name: "Biome configuration",
       status: "fail",
     };
@@ -74,20 +84,20 @@ const checkBiomeConfig = (): DiagnosticCheck => {
       config.extends.includes("ultracite/biome/core")
     ) {
       return {
-        message: "biome.json(c) extends ultracite/biome/core",
+        message: `${biomeConfigFile} extends ultracite/biome/core`,
         name: "Biome configuration",
         status: "pass",
       };
     }
 
     return {
-      message: "biome.json(c) exists but doesn't extend ultracite/biome/core",
+      message: `${biomeConfigFile} exists but doesn't extend ultracite/biome/core`,
       name: "Biome configuration",
       status: "warn",
     };
   } catch {
     return {
-      message: "Could not parse biome.json(c) file",
+      message: `Could not parse ${biomeConfigFile} file`,
       name: "Biome configuration",
       status: "fail",
     };

--- a/packages/cli/src/linters/biome.ts
+++ b/packages/cli/src/linters/biome.ts
@@ -14,10 +14,19 @@ const defaultConfig = {
 const LEGACY_EXTEND_RE = /^ultracite\/(?!biome\/)(.+)$/u;
 
 const getBiomeConfigPath = (): string => {
-  // Check for biome.json first, then fall back to biome.jsonc
-  if (exists("./biome.json")) {
-    return "./biome.json";
+  // Check for Biome supported configuration files, in the following order
+  const biomeConfigFiles = [
+    "biome.json",
+    "biome.jsonc",
+    ".biome.json",
+    ".biome.jsonc",
+  ];
+  for (const file of biomeConfigFiles) {
+    if (exists(`./${file}`)) {
+      return `./${file}`;
+    }
   }
+  // Default to biome.jsonc if none found
   return "./biome.jsonc";
 };
 

--- a/packages/cli/src/linters/biome.ts
+++ b/packages/cli/src/linters/biome.ts
@@ -4,7 +4,7 @@ import type { options } from "@repo/data/options";
 import deepmerge from "deepmerge";
 
 import { biomeConfigSchema, parseJsonc } from "../schemas";
-import { exists, validateFrameworkName } from "../utils";
+import { biomeConfigNames, exists, validateFrameworkName } from "../utils";
 
 const defaultConfig = {
   $schema: "./node_modules/@biomejs/biome/configuration_schema.json",
@@ -14,14 +14,8 @@ const defaultConfig = {
 const LEGACY_EXTEND_RE = /^ultracite\/(?!biome\/)(.+)$/u;
 
 const getBiomeConfigPath = (): string => {
-  // Check for Biome supported configuration files, in the following order
-  const biomeConfigFiles = [
-    "biome.json",
-    "biome.jsonc",
-    ".biome.json",
-    ".biome.jsonc",
-  ];
-  for (const file of biomeConfigFiles) {
+  // Check for Biome's supported configuration files, in resolution order.
+  for (const file of biomeConfigNames) {
     if (exists(`./${file}`)) {
       return `./${file}`;
     }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -112,7 +112,12 @@ export const validateFrameworkName = (name: string): string => {
 export type Linter = "biome" | "eslint" | "oxlint";
 
 // Config file names for each linter
-const biomeConfigNames = ["biome.json", "biome.jsonc"] as const;
+const biomeConfigNames = [
+  "biome.json",
+  "biome.jsonc",
+  ".biome.json",
+  ".biome.jsonc",
+] as const;
 
 const eslintConfigNames = [
   "eslint.config.mjs",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -111,8 +111,10 @@ export const validateFrameworkName = (name: string): string => {
 
 export type Linter = "biome" | "eslint" | "oxlint";
 
-// Config file names for each linter
-const biomeConfigNames = [
+// Config file names for each linter. Exported as the canonical Biome list so
+// doctor.ts and the Biome resolver stay in sync (Biome's documented resolution
+// order: https://biomejs.dev/guides/configure-biome/#configuration-file-resolution).
+export const biomeConfigNames = [
   "biome.json",
   "biome.jsonc",
   ".biome.json",


### PR DESCRIPTION
## Description

Recognize .biome.json and .biome.jsonc as valid Biome config files across the CLI.

## Related Issues

Closes #700 

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [ ] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes

Local run - `packages/cli`

- [x] bun test
- [x] bun build
- [x] bun bench

Local run `root`

- [x] bun check
- [x] bun fix
- [x] bun test
