### PR TITLE
fix: pre-format generated oxlint.config.ts to match oxfmt rules

### DIFF
--- a/.changeset/oxlint-config-formatting.md
+++ b/.changeset/oxlint-config-formatting.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Fix generated `oxlint.config.ts` to be pre-formatted according to oxfmt rules, so `ultracite check` passes immediately after `ultracite init` without requiring a separate format step.

--- a/packages/cli/src/linters/oxlint.ts
+++ b/packages/cli/src/linters/oxlint.ts
@@ -20,22 +20,21 @@ const getOxlintConfigIdentifier = (configPath: string) => {
 };
 
 const generateConfigContent = (extendsList: string[]) => {
-  const imports = extendsList
-    .map((ext) => `import ${getOxlintConfigIdentifier(ext)} from "${ext}";`)
-    .join("\n");
+  const imports = [
+    `import { defineConfig } from "oxlint";`,
+    ...extendsList.map(
+      (ext) => `import ${getOxlintConfigIdentifier(ext)} from "${ext}";`
+    ),
+  ].join("\n");
 
   const identifiers = extendsList
-    .map((ext) => `    ${getOxlintConfigIdentifier(ext)},`)
-    .join("\n");
+    .map((ext) => getOxlintConfigIdentifier(ext))
+    .join(", ");
 
-  return `import { defineConfig } from "oxlint";
-
-${imports}
+  return `${imports}
 
 export default defineConfig({
-  extends: [
-${identifiers}
-  ],
+  extends: [${identifiers}],
   ignorePatterns: core.ignorePatterns,
 });
 `;


### PR DESCRIPTION
## Summary

The `generateConfigContent` function in `packages/cli/src/linters/oxlint.ts` produced an `oxlint.config.ts` that did not conform to `oxfmt` formatting rules. This meant `ultracite check` would immediately fail after a fresh `ultracite init` with the Oxlint + Oxfmt preset.

Three formatting violations in the generated output:

1. **Blank line between imports** — `oxfmt` collapses consecutive imports without grouping gaps
2. **Multiline `extends` array** — oxfmt collapses arrays that fit within `printWidth: 80` to a single line
3. **Trailing comma in collapsed array** — removed when the array is collapsed to one line

The template now produces output that passes `oxfmt --check` immediately after generation.

**Before:**
```ts
import { defineConfig } from "oxlint";

import core from "ultracite/oxlint/core";

export default defineConfig({
  extends: [
    core,
  ],
  ignorePatterns: core.ignorePatterns,
});
```

**After:**
```ts
import { defineConfig } from "oxlint";
import core from "ultracite/oxlint/core";

export default defineConfig({
  extends: [core],
  ignorePatterns: core.ignorePatterns,
});
```

Closes #706