### PR TITLE
fix: move mockFs to module scope for unicorn/consistent-function-scoping

### DIFF
--- a/packages/cli/__tests__/utils.test.ts
+++ b/packages/cli/__tests__/utils.test.ts
@@ -432,44 +432,41 @@ describe("validateFrameworkName", () => {
   });
 });
 
+const mockFs = (files: Record<string, string>, globResults: string[] = []) => {
+  mock.module("node:fs/promises", () => ({
+    access: mock((path: string) =>
+      path in files ? Promise.resolve() : Promise.reject(new Error("ENOENT"))
+    ),
+    readFile: mock((path: string) =>
+      path in files
+        ? Promise.resolve(files[path])
+        : Promise.reject(new Error("ENOENT"))
+    ),
+    writeFile: mock(() => Promise.resolve()),
+  }));
+  mock.module("node:fs", () => ({
+    accessSync: mock((path: string) => {
+      if (!(path in files)) {
+        throw new Error("ENOENT");
+      }
+    }),
+    existsSync: mock((path: string) => path in files),
+    readFileSync: mock((path: string) => {
+      if (path in files) {
+        return files[path];
+      }
+      throw new Error("ENOENT");
+    }),
+  }));
+  mock.module("glob", () => ({
+    glob: mock(() => Promise.resolve(globResults)),
+  }));
+};
+
 describe("detectFrameworks", () => {
   beforeEach(() => {
     mock.restore();
   });
-
-  const mockFs = (
-    files: Record<string, string>,
-    globResults: string[] = []
-  ) => {
-    mock.module("node:fs/promises", () => ({
-      access: mock((path: string) =>
-        path in files ? Promise.resolve() : Promise.reject(new Error("ENOENT"))
-      ),
-      readFile: mock((path: string) =>
-        path in files
-          ? Promise.resolve(files[path])
-          : Promise.reject(new Error("ENOENT"))
-      ),
-      writeFile: mock(() => Promise.resolve()),
-    }));
-    mock.module("node:fs", () => ({
-      accessSync: mock((path: string) => {
-        if (!(path in files)) {
-          throw new Error("ENOENT");
-        }
-      }),
-      existsSync: mock((path: string) => path in files),
-      readFileSync: mock((path: string) => {
-        if (path in files) {
-          return files[path];
-        }
-        throw new Error("ENOENT");
-      }),
-    }));
-    mock.module("glob", () => ({
-      glob: mock(() => Promise.resolve(globResults)),
-    }));
-  };
 
   test("detects frameworks from root package.json deps", async () => {
     mockFs({


### PR DESCRIPTION
## Summary

The `mockFs` helper inside the `detectFrameworks` describe block in `packages/cli/__tests__/utils.test.ts` triggered the `unicorn/consistent-function-scoping` rule because it does not capture any variables from its parent scope.

Moves `mockFs` to module scope (above the describe block) so it no longer violates the rule. All 30 tests continue to pass.
