### PR TITLE
fix(oxlint): relax filename-case for TanStack route files

### DIFF
--- a/.changeset/mighty-states-do.md
+++ b/.changeset/mighty-states-do.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Fix the Oxlint TanStack preset so route files under `routes/` and `app/routes/` are exempt from `unicorn/filename-case`, matching the documented 7.8.0 behavior.

--- a/packages/cli/__tests__/oxlint-config.test.ts
+++ b/packages/cli/__tests__/oxlint-config.test.ts
@@ -272,3 +272,33 @@ describe("oxlint vitest config", () => {
     });
   });
 });
+
+describe("oxlint tanstack config", () => {
+  test("disables filename-case for TanStack route files", async () => {
+    const config = await readOxlintConfig("tanstack");
+
+    const routeOverride = config.overrides?.find(
+      (override: { files?: string[] }) =>
+        override.files?.includes("**/routes/**/*.{tsx,ts}") &&
+        override.files?.includes("**/app/routes/**/*.{tsx,ts}")
+    );
+
+    expect(routeOverride).toBeDefined();
+    expect(routeOverride?.rules?.["unicorn/filename-case"]).toBe("off");
+  });
+
+  test("keeps routeTree.gen.ts filename-case override", async () => {
+    const config = await readOxlintConfig("tanstack");
+
+    const routeTreeOverride = config.overrides?.find(
+      (override: { files?: string[] }) =>
+        override.files?.includes("**/routeTree.gen.ts")
+    );
+
+    expect(routeTreeOverride).toBeDefined();
+    expect(routeTreeOverride?.rules?.["unicorn/filename-case"]).toBe("off");
+    expect(
+      routeTreeOverride?.rules?.["unicorn/no-abusive-eslint-disable"]
+    ).toBe("off");
+  });
+});

--- a/packages/cli/config/oxlint/tanstack/index.mjs
+++ b/packages/cli/config/oxlint/tanstack/index.mjs
@@ -3,6 +3,12 @@ import { defineConfig } from "oxlint";
 export default defineConfig({
   overrides: [
     {
+      files: ["**/routes/**/*.{tsx,ts}", "**/app/routes/**/*.{tsx,ts}"],
+      rules: {
+        "unicorn/filename-case": "off",
+      },
+    },
+    {
       files: ["**/routeTree.gen.ts"],
       rules: {
         "unicorn/filename-case": "off",


### PR DESCRIPTION
## Description

This PR fixes the Oxlint TanStack preset so TanStack route files are exempt from `unicorn/filename-case`.

The `7.8.0` changelog says the TanStack preset relaxes file-naming conventions for both `routes/` directories and the generated `routeTree.gen.ts`, but the Oxlint preset only handled `routeTree.gen.ts`. This change adds an override for route files under `routes/` and `app/routes/`, aligning Oxlint with the documented behavior and the existing Biome TanStack preset.

## Related Issues

Closes #709

## Checklist

* [x] I've reviewed my code
* [x] I've written tests
* [x] I've generated a change set file
* [x] I've updated the docs, if necessary

## Screenshots (if applicable)

N/A — this is a configuration-only change.

## Additional Notes

Test coverage was added for the Oxlint TanStack preset to verify that:

* `unicorn/filename-case` is disabled for TanStack route files.
* The existing `routeTree.gen.ts` override remains in place.