### PR TITLE
feat: migrate stale linter configs during init

### DIFF
--- a/.changeset/clean-pandas-migrate.md
+++ b/.changeset/clean-pandas-migrate.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Migrate stale linter and formatter configuration when switching toolchains during init.

--- a/.changeset/clean-pandas-migrate.md
+++ b/.changeset/clean-pandas-migrate.md
@@ -2,4 +2,4 @@
 "ultracite": patch
 ---
 
-Migrate stale linter and formatter configuration when switching toolchains during init.
+Migrate stale linter and formatter configuration when switching toolchains during init. Running `ultracite init` now removes config files and dependencies for unselected Biome, ESLint/Prettier/Stylelint, or Oxlint/Oxfmt setups before writing the selected toolchain config.

--- a/packages/cli/__tests__/initialize.test.ts
+++ b/packages/cli/__tests__/initialize.test.ts
@@ -11,6 +11,7 @@ import {
   initializePreCommit,
   initializePrecommitHook,
   installDependencies,
+  migrateLinterConfig,
   upsertAgentFile,
   upsertAgents,
   upsertBiomeConfig,
@@ -32,6 +33,7 @@ mock.module("node:fs/promises", () => ({
   access: mock(() => Promise.reject(new Error("ENOENT"))),
   mkdir: mock(() => Promise.resolve()),
   readFile: mock(() => Promise.resolve('{"name": "test"}')),
+  rm: mock(() => Promise.resolve()),
   writeFile: mock(() => Promise.resolve()),
 }));
 
@@ -1914,6 +1916,134 @@ describe("helper functions", () => {
 
       expect(mockAddDep).toHaveBeenCalled();
       expect(calls.some((c) => c.workspace === true)).toBe(true);
+    });
+  });
+
+  describe("migrateLinterConfig", () => {
+    test("removes stale Biome and ESLint config when migrating to oxlint", async () => {
+      const removedFiles: string[] = [];
+      const mockWriteFile = mock((_path: string, _content: string) =>
+        Promise.resolve()
+      );
+
+      mock.module("node:fs", () => ({
+        accessSync: mock((path: string) => {
+          if (
+            [
+              "./biome.jsonc",
+              "./eslint.config.mjs",
+              "./prettier.config.mjs",
+              "./stylelint.config.mjs",
+            ].includes(path)
+          ) {
+            return;
+          }
+          throw new Error("ENOENT");
+        }),
+        lstatSync: mock(() => ({ isSymbolicLink: () => false })),
+        mkdirSync: mock(() => {}),
+        realpathSync: mock((path: string) => path),
+      }));
+
+      mock.module("node:fs/promises", () => ({
+        mkdir: mock(() => Promise.resolve()),
+        readFile: mock(() =>
+          Promise.resolve(
+            JSON.stringify({
+              devDependencies: {
+                "@biomejs/biome": "latest",
+                eslint: "latest",
+                oxfmt: "latest",
+                oxlint: "latest",
+                prettier: "latest",
+                stylelint: "latest",
+                ultracite: "latest",
+              },
+              prettier: {},
+              stylelint: {},
+            })
+          )
+        ),
+        rm: mock((path: string) => {
+          removedFiles.push(path);
+          return Promise.resolve();
+        }),
+        writeFile: mockWriteFile,
+      }));
+
+      await migrateLinterConfig("oxlint", true);
+
+      expect(removedFiles).toContain("./biome.jsonc");
+      expect(removedFiles).toContain("./eslint.config.mjs");
+      expect(removedFiles).toContain("./prettier.config.mjs");
+      expect(removedFiles).toContain("./stylelint.config.mjs");
+      expect(removedFiles).not.toContain("./oxlint.config.ts");
+      expect(removedFiles).not.toContain("./oxfmt.config.ts");
+
+      const packageJson = JSON.parse(
+        mockWriteFile.mock.calls.at(-1)?.[1] as string
+      );
+      expect(packageJson.devDependencies).toEqual({
+        oxfmt: "latest",
+        oxlint: "latest",
+        ultracite: "latest",
+      });
+      expect(packageJson.prettier).toBeUndefined();
+      expect(packageJson.stylelint).toBeUndefined();
+    });
+
+    test("removes stale Oxlint config when migrating to biome", async () => {
+      const removedFiles: string[] = [];
+      const mockWriteFile = mock((_path: string, _content: string) =>
+        Promise.resolve()
+      );
+
+      mock.module("node:fs", () => ({
+        accessSync: mock((path: string) => {
+          if (["./oxlint.config.ts", "./oxfmt.config.ts"].includes(path)) {
+            return;
+          }
+          throw new Error("ENOENT");
+        }),
+        lstatSync: mock(() => ({ isSymbolicLink: () => false })),
+        mkdirSync: mock(() => {}),
+        realpathSync: mock((path: string) => path),
+      }));
+
+      mock.module("node:fs/promises", () => ({
+        mkdir: mock(() => Promise.resolve()),
+        readFile: mock(() =>
+          Promise.resolve(
+            JSON.stringify({
+              devDependencies: {
+                "@biomejs/biome": "latest",
+                oxfmt: "latest",
+                oxlint: "latest",
+                ultracite: "latest",
+              },
+            })
+          )
+        ),
+        rm: mock((path: string) => {
+          removedFiles.push(path);
+          return Promise.resolve();
+        }),
+        writeFile: mockWriteFile,
+      }));
+
+      await migrateLinterConfig("biome", true);
+
+      expect(removedFiles).toContain("./oxlint.config.ts");
+      expect(removedFiles).toContain("./oxfmt.config.ts");
+      expect(removedFiles).not.toContain("./biome.jsonc");
+
+      const packageJson = JSON.parse(
+        mockWriteFile.mock.calls.at(-1)?.[1] as string
+      );
+      expect(packageJson.devDependencies).toEqual({
+        "@biomejs/biome": "latest",
+        ultracite: "latest",
+      });
     });
   });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -8,7 +8,13 @@ import { parse } from "jsonc-parser";
 import packageJson from "../../package.json" with { type: "json" };
 import { runCommandSync } from "../run-command";
 import { readPackageJsonSync } from "../schemas";
-import { biomeConfigNames, detectLinter } from "../utils";
+import {
+  biomeConfigNames,
+  detectLinter,
+  eslintConfigNames,
+  prettierConfigNames,
+  stylelintConfigNames,
+} from "../utils";
 import type { Linter } from "../utils";
 
 interface DiagnosticCheck {
@@ -97,17 +103,8 @@ const checkBiomeConfig = (): DiagnosticCheck => {
 };
 
 const checkEslintConfig = (): DiagnosticCheck => {
-  const eslintConfigPaths = [
-    "eslint.config.mjs",
-    "eslint.config.js",
-    "eslint.config.cjs",
-    "eslint.config.ts",
-    "eslint.config.mts",
-    "eslint.config.cts",
-  ];
-
   let configPath: string | null = null;
-  for (const eslintPath of eslintConfigPaths) {
+  for (const eslintPath of eslintConfigNames) {
     const fullPath = path.join(process.cwd(), eslintPath);
     if (existsSync(fullPath)) {
       configPath = fullPath;
@@ -149,21 +146,7 @@ const checkEslintConfig = (): DiagnosticCheck => {
 };
 
 const checkPrettierConfig = (): DiagnosticCheck => {
-  const prettierConfigPaths = [
-    "prettier.config.mjs",
-    "prettier.config.js",
-    "prettier.config.cjs",
-    "prettier.config.ts",
-    ".prettierrc",
-    ".prettierrc.json",
-    ".prettierrc.mjs",
-    ".prettierrc.cjs",
-    ".prettierrc.js",
-    ".prettierrc.yml",
-    ".prettierrc.yaml",
-  ];
-
-  for (const prettierPath of prettierConfigPaths) {
+  for (const prettierPath of prettierConfigNames) {
     if (existsSync(path.join(process.cwd(), prettierPath))) {
       return {
         message: `Prettier configuration found (${prettierPath})`,
@@ -181,19 +164,7 @@ const checkPrettierConfig = (): DiagnosticCheck => {
 };
 
 const checkStylelintConfig = (): DiagnosticCheck => {
-  const stylelintConfigPaths = [
-    "stylelint.config.mjs",
-    "stylelint.config.js",
-    "stylelint.config.cjs",
-    ".stylelintrc",
-    ".stylelintrc.json",
-    ".stylelintrc.mjs",
-    ".stylelintrc.js",
-    ".stylelintrc.yml",
-    ".stylelintrc.yaml",
-  ];
-
-  for (const stylelintPath of stylelintConfigPaths) {
+  for (const stylelintPath of stylelintConfigNames) {
     if (existsSync(path.join(process.cwd(), stylelintPath))) {
       return {
         message: `Stylelint configuration found (${stylelintPath})`,

--- a/packages/cli/src/initialize.ts
+++ b/packages/cli/src/initialize.ts
@@ -38,12 +38,20 @@ import {
   assertSupportedPackageManagerName,
   normalizePackageManager,
 } from "./package-manager";
+import { readPackageJson } from "./schemas";
 import {
   getUltraciteSkillInstallCommand,
   maybeInstallUltraciteSkill,
 } from "./skill";
 import { tsconfig } from "./tsconfig";
-import { detectFrameworks, isMonorepo, updatePackageJson } from "./utils";
+import {
+  biomeConfigNames,
+  detectFrameworks,
+  exists,
+  isMonorepo,
+  updatePackageJson,
+  writeProjectFile,
+} from "./utils";
 
 const schemaVersion = packageJson.devDependencies["@biomejs/biome"];
 const ultraciteVersion = packageJson.version;
@@ -192,6 +200,205 @@ const buildNoInstallDevDependencies = (
   }
 
   return devDependencies;
+};
+
+const eslintConfigFiles = [
+  "eslint.config.mjs",
+  "eslint.config.js",
+  "eslint.config.cjs",
+  "eslint.config.ts",
+  "eslint.config.mts",
+  "eslint.config.cts",
+] as const;
+
+const legacyEslintConfigFiles = [
+  ".eslintrc",
+  ".eslintrc.json",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
+  ".eslintrc.yaml",
+  ".eslintrc.yml",
+] as const;
+
+const prettierConfigFiles = [
+  ".prettierrc",
+  ".prettierrc.json",
+  ".prettierrc.json5",
+  ".prettierrc.js",
+  ".prettierrc.cjs",
+  ".prettierrc.mjs",
+  ".prettierrc.ts",
+  ".prettierrc.cts",
+  ".prettierrc.mts",
+  ".prettierrc.yaml",
+  ".prettierrc.yml",
+  ".prettierrc.toml",
+  "prettier.config.js",
+  "prettier.config.cjs",
+  "prettier.config.mjs",
+  "prettier.config.ts",
+  "prettier.config.cts",
+  "prettier.config.mts",
+] as const;
+
+const stylelintConfigFiles = [
+  ".stylelintrc",
+  ".stylelintrc.json",
+  ".stylelintrc.js",
+  ".stylelintrc.cjs",
+  ".stylelintrc.mjs",
+  ".stylelintrc.yaml",
+  ".stylelintrc.yml",
+  "stylelint.config.js",
+  "stylelint.config.cjs",
+  "stylelint.config.mjs",
+] as const;
+
+const oxlintConfigFiles = [".oxlintrc.json", "oxlint.config.ts"] as const;
+const oxfmtConfigFiles = ["oxfmt.config.ts"] as const;
+
+const eslintDevDependencyNames = new Set([
+  ...Object.keys(eslintCoreDevDependencies),
+  ...Object.values(eslintFrameworkDevDependencies).flatMap((dependencies) =>
+    Object.keys(dependencies ?? {})
+  ),
+]);
+
+const dependencyNamesByLinter: Record<Linter, Set<string>> = {
+  biome: new Set(["@biomejs/biome"]),
+  eslint: eslintDevDependencyNames,
+  oxlint: new Set(["oxfmt", "oxlint", "oxlint-tsgolint"]),
+};
+
+const removeProjectFile = async (filePath: string): Promise<boolean> => {
+  const normalizedPath = filePath.startsWith("./") ? filePath : `./${filePath}`;
+  if (!exists(normalizedPath)) {
+    return false;
+  }
+
+  const { rm } = await import("node:fs/promises");
+  await rm(normalizedPath, { force: true });
+  return true;
+};
+
+const prunePackageJsonForLinter = async (linter: Linter): Promise<boolean> => {
+  const packageJsonObject = await readPackageJson();
+  if (!packageJsonObject) {
+    return false;
+  }
+
+  const dependencyNamesToRemove = new Set<string>();
+  for (const [tool, dependencyNames] of Object.entries(
+    dependencyNamesByLinter
+  )) {
+    if (tool !== linter) {
+      for (const dependencyName of dependencyNames) {
+        dependencyNamesToRemove.add(dependencyName);
+      }
+    }
+  }
+
+  let changed = false;
+  const nextPackageJson = { ...packageJsonObject };
+
+  for (const key of [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+  ] as const) {
+    const dependencies = nextPackageJson[key];
+    if (!dependencies) {
+      continue;
+    }
+
+    const dependencyEntries = Object.entries(dependencies);
+    const nextDependencyEntries = dependencyEntries.filter(
+      ([dependencyName]) => !dependencyNamesToRemove.has(dependencyName)
+    );
+    if (nextDependencyEntries.length !== dependencyEntries.length) {
+      changed = true;
+    }
+    const nextDependencies = Object.fromEntries(nextDependencyEntries);
+
+    nextPackageJson[key] = nextDependencies;
+  }
+
+  if ("prettier" in nextPackageJson) {
+    delete nextPackageJson.prettier;
+    changed = true;
+  }
+  if ("stylelint" in nextPackageJson) {
+    delete nextPackageJson.stylelint;
+    changed = true;
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  await writeProjectFile(
+    "package.json",
+    `${JSON.stringify(nextPackageJson, null, 2)}\n`
+  );
+  return true;
+};
+
+export const migrateLinterConfig = async (
+  linter: Linter,
+  quiet = false
+): Promise<void> => {
+  const s = spinner();
+
+  if (!quiet) {
+    s.start("Checking for stale linter configuration...");
+  }
+
+  const filesToRemove = new Set<string>();
+
+  if (linter !== "biome") {
+    for (const file of biomeConfigNames) {
+      filesToRemove.add(file);
+    }
+  }
+
+  if (linter !== "eslint") {
+    for (const file of eslintConfigFiles) {
+      filesToRemove.add(file);
+    }
+    for (const file of prettierConfigFiles) {
+      filesToRemove.add(file);
+    }
+    for (const file of stylelintConfigFiles) {
+      filesToRemove.add(file);
+    }
+  }
+
+  for (const file of legacyEslintConfigFiles) {
+    filesToRemove.add(file);
+  }
+
+  if (linter !== "oxlint") {
+    for (const file of oxlintConfigFiles) {
+      filesToRemove.add(file);
+    }
+    for (const file of oxfmtConfigFiles) {
+      filesToRemove.add(file);
+    }
+  }
+
+  const removedFiles = await Promise.all(
+    [...filesToRemove].map((file) => removeProjectFile(file))
+  );
+  const prunedPackageJson = await prunePackageJsonForLinter(linter);
+  const changed = removedFiles.some(Boolean) || prunedPackageJson;
+
+  if (!quiet) {
+    s.stop(
+      changed
+        ? "Stale linter configuration migrated."
+        : "No stale linter configuration found."
+    );
+  }
 };
 
 export const installDependencies = async (
@@ -1083,6 +1290,7 @@ export const initialize = async (flags?: InitializeFlags) => {
     );
 
     await upsertTsConfig(quiet);
+    await migrateLinterConfig(linter, quiet);
 
     // Create config for selected linter
     if (linter === "biome") {

--- a/packages/cli/src/initialize.ts
+++ b/packages/cli/src/initialize.ts
@@ -47,8 +47,14 @@ import { tsconfig } from "./tsconfig";
 import {
   biomeConfigNames,
   detectFrameworks,
+  eslintConfigNames,
   exists,
   isMonorepo,
+  legacyEslintConfigNames,
+  oxfmtConfigNames,
+  oxlintConfigNames,
+  prettierConfigNames,
+  stylelintConfigNames,
   updatePackageJson,
   writeProjectFile,
 } from "./utils";
@@ -202,61 +208,6 @@ const buildNoInstallDevDependencies = (
   return devDependencies;
 };
 
-const eslintConfigFiles = [
-  "eslint.config.mjs",
-  "eslint.config.js",
-  "eslint.config.cjs",
-  "eslint.config.ts",
-  "eslint.config.mts",
-  "eslint.config.cts",
-] as const;
-
-const legacyEslintConfigFiles = [
-  ".eslintrc",
-  ".eslintrc.json",
-  ".eslintrc.js",
-  ".eslintrc.cjs",
-  ".eslintrc.yaml",
-  ".eslintrc.yml",
-] as const;
-
-const prettierConfigFiles = [
-  ".prettierrc",
-  ".prettierrc.json",
-  ".prettierrc.json5",
-  ".prettierrc.js",
-  ".prettierrc.cjs",
-  ".prettierrc.mjs",
-  ".prettierrc.ts",
-  ".prettierrc.cts",
-  ".prettierrc.mts",
-  ".prettierrc.yaml",
-  ".prettierrc.yml",
-  ".prettierrc.toml",
-  "prettier.config.js",
-  "prettier.config.cjs",
-  "prettier.config.mjs",
-  "prettier.config.ts",
-  "prettier.config.cts",
-  "prettier.config.mts",
-] as const;
-
-const stylelintConfigFiles = [
-  ".stylelintrc",
-  ".stylelintrc.json",
-  ".stylelintrc.js",
-  ".stylelintrc.cjs",
-  ".stylelintrc.mjs",
-  ".stylelintrc.yaml",
-  ".stylelintrc.yml",
-  "stylelint.config.js",
-  "stylelint.config.cjs",
-  "stylelint.config.mjs",
-] as const;
-
-const oxlintConfigFiles = [".oxlintrc.json", "oxlint.config.ts"] as const;
-const oxfmtConfigFiles = ["oxfmt.config.ts"] as const;
-
 const eslintDevDependencyNames = new Set([
   ...Object.keys(eslintCoreDevDependencies),
   ...Object.values(eslintFrameworkDevDependencies).flatMap((dependencies) =>
@@ -362,26 +313,29 @@ export const migrateLinterConfig = async (
   }
 
   if (linter !== "eslint") {
-    for (const file of eslintConfigFiles) {
+    for (const file of eslintConfigNames) {
       filesToRemove.add(file);
     }
-    for (const file of prettierConfigFiles) {
+    for (const file of prettierConfigNames) {
       filesToRemove.add(file);
     }
-    for (const file of stylelintConfigFiles) {
+    for (const file of stylelintConfigNames) {
       filesToRemove.add(file);
     }
   }
 
-  for (const file of legacyEslintConfigFiles) {
+  // Legacy (pre-flat) ESLint configs are always removed: Ultracite's ESLint
+  // setup writes a flat config, and a leftover .eslintrc would conflict with it
+  // even when ESLint remains the selected linter.
+  for (const file of legacyEslintConfigNames) {
     filesToRemove.add(file);
   }
 
   if (linter !== "oxlint") {
-    for (const file of oxlintConfigFiles) {
+    for (const file of oxlintConfigNames) {
       filesToRemove.add(file);
     }
-    for (const file of oxfmtConfigFiles) {
+    for (const file of oxfmtConfigNames) {
       filesToRemove.add(file);
     }
   }

--- a/packages/cli/src/linters/eslint.ts
+++ b/packages/cli/src/linters/eslint.ts
@@ -1,17 +1,13 @@
 import type { options } from "@repo/data/options";
 
-import { exists, validateFrameworkName, writeProjectFile } from "../utils";
+import {
+  eslintConfigNames,
+  exists,
+  validateFrameworkName,
+  writeProjectFile,
+} from "../utils";
 
-// All possible ESLint flat config file locations
-// https://eslint.org/docs/latest/use/configure/configuration-files
-const eslintConfigPaths = [
-  "./eslint.config.mjs",
-  "./eslint.config.js",
-  "./eslint.config.cjs",
-  "./eslint.config.ts",
-  "./eslint.config.mts",
-  "./eslint.config.cts",
-] as const;
+const eslintConfigPaths = eslintConfigNames.map((name) => `./${name}`);
 
 const defaultConfigPath = "./eslint.config.mjs";
 

--- a/packages/cli/src/linters/eslint.ts
+++ b/packages/cli/src/linters/eslint.ts
@@ -60,6 +60,6 @@ export const eslint = {
   },
   update: async (opts?: EslintOptions) => {
     const config = generateEslintConfig(opts);
-    await writeProjectFile(defaultConfigPath, config);
+    await writeProjectFile(getEslintConfigPath() ?? defaultConfigPath, config);
   },
 };

--- a/packages/cli/src/linters/prettier.ts
+++ b/packages/cli/src/linters/prettier.ts
@@ -1,35 +1,14 @@
 import type { options } from "@repo/data/options";
 
 import { readPackageJsonSync } from "../schemas";
-import { exists, validateFrameworkName, writeProjectFile } from "../utils";
+import {
+  exists,
+  prettierConfigNames,
+  validateFrameworkName,
+  writeProjectFile,
+} from "../utils";
 
-// All possible Prettier config file locations
-// https://prettier.io/docs/en/configuration.html
-const prettierConfigPaths = [
-  // JS/TS configs (ESM)
-  "./.prettierrc.mjs",
-  "./prettier.config.mjs",
-  "./.prettierrc.mts",
-  "./prettier.config.mts",
-  // JS/TS configs (CJS)
-  "./.prettierrc.cjs",
-  "./prettier.config.cjs",
-  "./.prettierrc.cts",
-  "./prettier.config.cts",
-  // JS/TS configs (depends on package.json type)
-  "./.prettierrc.js",
-  "./prettier.config.js",
-  "./.prettierrc.ts",
-  "./prettier.config.ts",
-  // JSON/YAML configs
-  "./.prettierrc",
-  "./.prettierrc.json",
-  "./.prettierrc.json5",
-  "./.prettierrc.yml",
-  "./.prettierrc.yaml",
-  // TOML config
-  "./.prettierrc.toml",
-] as const;
+const prettierConfigPaths = prettierConfigNames.map((name) => `./${name}`);
 
 const defaultConfigPath = "./prettier.config.mjs";
 

--- a/packages/cli/src/linters/prettier.ts
+++ b/packages/cli/src/linters/prettier.ts
@@ -98,6 +98,12 @@ export const prettier = {
   },
   update: async (opts?: PrettierOptions) => {
     const config = generatePrettierConfig(opts);
-    await writeProjectFile(defaultConfigPath, config);
+    const existingPath = getPrettierConfigPath();
+    await writeProjectFile(
+      existingPath === "./package.json"
+        ? defaultConfigPath
+        : (existingPath ?? defaultConfigPath),
+      config
+    );
   },
 };

--- a/packages/cli/src/linters/stylelint.ts
+++ b/packages/cli/src/linters/stylelint.ts
@@ -1,24 +1,7 @@
 import { readPackageJsonSync } from "../schemas";
-import { exists, writeProjectFile } from "../utils";
+import { exists, stylelintConfigNames, writeProjectFile } from "../utils";
 
-// All possible Stylelint config file locations
-// https://stylelint.io/user-guide/configure
-const stylelintConfigPaths = [
-  // JS configs (ESM)
-  "./.stylelintrc.mjs",
-  "./stylelint.config.mjs",
-  // JS configs (CJS)
-  "./.stylelintrc.cjs",
-  "./stylelint.config.cjs",
-  // JS configs (depends on package.json type)
-  "./.stylelintrc.js",
-  "./stylelint.config.js",
-  // JSON/YAML configs
-  "./.stylelintrc",
-  "./.stylelintrc.json",
-  "./.stylelintrc.yml",
-  "./.stylelintrc.yaml",
-] as const;
+const stylelintConfigPaths = stylelintConfigNames.map((name) => `./${name}`);
 
 const defaultConfigPath = "./stylelint.config.mjs";
 

--- a/packages/cli/src/linters/stylelint.ts
+++ b/packages/cli/src/linters/stylelint.ts
@@ -58,6 +58,12 @@ export const stylelint = {
   },
   update: async () => {
     const config = generateStylelintConfig();
-    await writeProjectFile(defaultConfigPath, config);
+    const existingPath = getStylelintConfigPath();
+    await writeProjectFile(
+      existingPath === "./package.json"
+        ? defaultConfigPath
+        : (existingPath ?? defaultConfigPath),
+      config
+    );
   },
 };

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -196,9 +196,10 @@ export const validateFrameworkName = (name: string): string => {
 
 export type Linter = "biome" | "eslint" | "oxlint";
 
-// Config file names for each linter. Exported as the canonical Biome list so
-// doctor.ts and the Biome resolver stay in sync (Biome's documented resolution
-// order: https://biomejs.dev/guides/configure-biome/#configuration-file-resolution).
+// Canonical config file-name lists for each tool. These are the single source
+// of truth shared by the linter writers, the init migration step, and doctor.ts
+// so the lists can't drift apart. Ordering matters: the writers return the first
+// existing match, so entries are listed in resolution precedence.
 export const biomeConfigNames = [
   "biome.json",
   "biome.jsonc",
@@ -206,7 +207,9 @@ export const biomeConfigNames = [
   ".biome.jsonc",
 ] as const;
 
-const eslintConfigNames = [
+// ESLint flat config file locations.
+// https://eslint.org/docs/latest/use/configure/configuration-files
+export const eslintConfigNames = [
   "eslint.config.mjs",
   "eslint.config.js",
   "eslint.config.cjs",
@@ -215,7 +218,68 @@ const eslintConfigNames = [
   "eslint.config.cts",
 ] as const;
 
-const oxlintConfigNames = [".oxlintrc.json", "oxlint.config.ts"];
+// Legacy (pre-flat) ESLint config file locations, migrated away from on init.
+export const legacyEslintConfigNames = [
+  ".eslintrc",
+  ".eslintrc.json",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
+  ".eslintrc.yaml",
+  ".eslintrc.yml",
+] as const;
+
+// Prettier config file locations.
+// https://prettier.io/docs/en/configuration.html
+export const prettierConfigNames = [
+  // JS/TS configs (ESM)
+  ".prettierrc.mjs",
+  "prettier.config.mjs",
+  ".prettierrc.mts",
+  "prettier.config.mts",
+  // JS/TS configs (CJS)
+  ".prettierrc.cjs",
+  "prettier.config.cjs",
+  ".prettierrc.cts",
+  "prettier.config.cts",
+  // JS/TS configs (depends on package.json type)
+  ".prettierrc.js",
+  "prettier.config.js",
+  ".prettierrc.ts",
+  "prettier.config.ts",
+  // JSON/YAML configs
+  ".prettierrc",
+  ".prettierrc.json",
+  ".prettierrc.json5",
+  ".prettierrc.yml",
+  ".prettierrc.yaml",
+  // TOML config
+  ".prettierrc.toml",
+] as const;
+
+// Stylelint config file locations.
+// https://stylelint.io/user-guide/configure
+export const stylelintConfigNames = [
+  // JS configs (ESM)
+  ".stylelintrc.mjs",
+  "stylelint.config.mjs",
+  // JS configs (CJS)
+  ".stylelintrc.cjs",
+  "stylelint.config.cjs",
+  // JS configs (depends on package.json type)
+  ".stylelintrc.js",
+  "stylelint.config.js",
+  // JSON/YAML configs
+  ".stylelintrc",
+  ".stylelintrc.json",
+  ".stylelintrc.yml",
+  ".stylelintrc.yaml",
+] as const;
+
+export const oxlintConfigNames = [
+  ".oxlintrc.json",
+  "oxlint.config.ts",
+] as const;
+export const oxfmtConfigNames = ["oxfmt.config.ts"] as const;
 
 // Map dep package names → framework IDs to enable. Multiple IDs cover
 // meta-frameworks (e.g. Next.js implies React).


### PR DESCRIPTION
## Summary

- Migrates stale linter config files during `ultracite init` when switching between Biome, ESLint, and Oxlint.
- Prunes stale linter dependencies and package-level Prettier/Stylelint config.
- Updates ESLint/Prettier/Stylelint writers to reuse detected config paths where possible.

## Testing

- `bun test packages/cli/__tests__`
- `bun run build`
- Packed and installed the local CLI in `C:\Users\mynameistito\code\ultracite-temp`, then verified `bunx ultracite doctor`.

Closes #721