### PR TITLE
feat: ignore .wrangler directories by default

### DIFF
--- a/.changeset/wild-ligers-shout.md
+++ b/.changeset/wild-ligers-shout.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Ignore `.wrangler` output directories by default

--- a/.changeset/wild-ligers-shout.md
+++ b/.changeset/wild-ligers-shout.md
@@ -2,4 +2,4 @@
 "ultracite": patch
 ---
 
-Ignore `.wrangler` output directories by default
+Ignore `.wrangler` and `.wrangler-dry-run` output directories by default

--- a/packages/cli/config/shared/ignores.mjs
+++ b/packages/cli/config/shared/ignores.mjs
@@ -21,6 +21,7 @@ export const ignorePatterns = [
   "**/.vercel",
   "**/.netlify",
   "**/.wrangler",
+  "**/.wrangler-dry-run",
   "**/.docusaurus",
   "**/.cache",
   "**/.parcel-cache",

--- a/packages/cli/config/shared/ignores.mjs
+++ b/packages/cli/config/shared/ignores.mjs
@@ -20,6 +20,7 @@ export const ignorePatterns = [
   "**/.turbo",
   "**/.vercel",
   "**/.netlify",
+  "**/.wrangler",
   "**/.docusaurus",
   "**/.cache",
   "**/.parcel-cache",


### PR DESCRIPTION
## Summary

Adds `.wrangler` to the canonical shared ignore patterns (`packages/cli/config/shared/ignores.mjs`), the single source of truth consumed by biome/core (via the prebuild `files.includes` sync), oxlint, eslint, and oxfmt. Cloudflare Wrangler's local dev/state output is now excluded from linting and formatting.

Closes #723 

## Details

- `**/.wrangler` follows the existing convention used by neighboring entries (`**/.turbo`, `**/.vercel`, `**/.netlify`, `**/.astro`), ignoring the directory at any depth.
- Includes a `patch` changeset.

## Verification

- `ultracite check` passes (0 warnings, 0 errors).
- Full CLI test suite passes (406 pass, 0 fail).
- `turbo types` passes.
- `bun ./scripts/validate-configs.ts` validates all Biome/ESLint/Oxlint configs.
