### PR TITLE
feat: ignore .yarn directories by default

### DIFF
--- a/.changeset/clean-aliens-help.md
+++ b/.changeset/clean-aliens-help.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Ignore `.yarn` directories by default

--- a/packages/cli/config/shared/ignores.mjs
+++ b/packages/cli/config/shared/ignores.mjs
@@ -42,6 +42,7 @@ export const ignorePatterns = [
   "**/schema.d.ts",
   "**/schema.graphql.d.ts",
   "**/*.d.ts.map",
+  "**/.yarn",
 
   // ── Test coverage ─────────────────────────────────────────────────
   "**/coverage",


### PR DESCRIPTION
## Description

Ignores `.yarn` directories by default. This directory is used for files that Yarn generates.

## Related Issues

Closes #725

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
