### PR TITLE
feat: sort package.json keys when using biome

### DIFF
--- a/.changeset/frank-trams-dress.md
+++ b/.changeset/frank-trams-dress.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Sort `package.json` keys when using Biome

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -92,7 +92,9 @@
         // Enforce ordering of TypeScript type alias members.
         "useSortedTypeFields": "on",
         // Enforce alphabetical ordering of GraphQL selection sets.
-        "useSortedSelectionSet": "on"
+        "useSortedSelectionSet": "on",
+        // Enforce ordering of package.json keys.
+        "useSortedPackageJson": "on"
       }
     }
   },


### PR DESCRIPTION
## Description

Biome 2.5.0 added support for sorting `package.json` keys. Therefore, I have updated Biome and enabled the [`useSortedPackageJson`](https://biomejs.dev/assist/actions/use-sorted-package-json/) action.

This change brings Biome more in line with the Oxfmt config, which has package.json sorting enabled.

https://github.com/haydenbleasel/ultracite/blob/f48ea13fb6bf0ce49932c5d0e4fadaa5e5d59f1f/packages/cli/config/oxfmt/index.mjs#L21

## Related Issues

Closes #728

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
