### PR TITLE
fix: pin TypeScript for SonarJS oxlint plugin

### DIFF
--- a/.changeset/silent-starfishes-fix.md
+++ b/.changeset/silent-starfishes-fix.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Pin TypeScript for Oxlint JS plugin installs so the SonarJS preset does not resolve broken compiler builds during plugin loading.

--- a/.changeset/silent-starfishes-fix.md
+++ b/.changeset/silent-starfishes-fix.md
@@ -2,4 +2,4 @@
 "ultracite": patch
 ---
 
-Pin TypeScript for Oxlint JS plugin installs so the SonarJS preset does not resolve broken compiler builds during plugin loading.
+Fix Oxlint initialization by installing a verified TypeScript build alongside the GitHub and SonarJS JS plugin presets, preventing `eslint-plugin-sonarjs` from resolving compiler builds that crash while loading.

--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
         "stylelint-config-idiomatic-order": "^10.0.0",
         "stylelint-config-standard": "^40.0.0",
         "stylelint-prettier": "^5.0.3",
+        "typescript": "5.8.3",
       },
       "peerDependencies": {
         "oxfmt": ">=0.1.0",
@@ -115,6 +116,7 @@
   },
   "overrides": {
     "@typescript-eslint/utils": "^8.62.1",
+    "typescript": "5.8.3",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -2865,7 +2867,7 @@
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
@@ -3235,8 +3237,6 @@
 
     "astrojs-compiler-sync/synckit": ["synckit@0.11.11", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw=="],
 
-    "blume/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
     "blume/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "brace-expansion/balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "^4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
@@ -3294,8 +3294,6 @@
     "eslint-plugin-github/eslint-plugin-prettier": ["eslint-plugin-prettier@5.5.4", "", { "dependencies": { "prettier-linter-helpers": "^1.0.0", "synckit": "^0.11.7" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg=="],
 
     "eslint-plugin-github/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
-
-    "eslint-plugin-github/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "@typescript-eslint/utils": "^8.62.1"
+    "@typescript-eslint/utils": "^8.62.1",
+    "typescript": "5.8.3"
   },
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {

--- a/packages/cli/__tests__/initialize.test.ts
+++ b/packages/cli/__tests__/initialize.test.ts
@@ -1667,7 +1667,11 @@ describe("helper functions", () => {
     });
 
     test("installs oxlint dependencies when linter is oxlint", async () => {
-      const mockAddDep = mock(() => Promise.resolve());
+      const installedPackages: string[] = [];
+      const mockAddDep = mock((pkg: string | string[]) => {
+        installedPackages.push(...(Array.isArray(pkg) ? pkg : [pkg]));
+        return Promise.resolve();
+      });
 
       mock.module("nypm", () => ({
         addDevDependency: mockAddDep,
@@ -1688,6 +1692,9 @@ describe("helper functions", () => {
 
       await installDependencies(npmPm, "oxlint", true);
       expect(mockAddDep).toHaveBeenCalled();
+      expect(installedPackages).toContain("eslint-plugin-github@6.0.0");
+      expect(installedPackages).toContain("eslint-plugin-sonarjs@^4.1.0");
+      expect(installedPackages).toContain("typescript@5.8.3");
     });
 
     test("updates package.json with eslint deps when install is false", async () => {
@@ -1726,9 +1733,11 @@ describe("helper functions", () => {
     });
 
     test("updates package.json with oxlint deps when install is false", async () => {
-      const mockWriteFile = mock((_path: string, _content: string) =>
-        Promise.resolve()
-      );
+      const writtenContents: string[] = [];
+      const mockWriteFile = mock((_path: string, content: string) => {
+        writtenContents.push(content);
+        return Promise.resolve();
+      });
       mock.module("node:fs/promises", () => ({
         access: mock(() => Promise.resolve()),
         mkdir: mock(() => Promise.resolve()),
@@ -1746,6 +1755,21 @@ describe("helper functions", () => {
 
       await installDependencies(npmPm, "oxlint", false);
       expect(mockWriteFile).toHaveBeenCalled();
+      expect(
+        writtenContents.some((content) =>
+          content.includes('"eslint-plugin-github": "6.0.0"')
+        )
+      ).toBe(true);
+      expect(
+        writtenContents.some((content) =>
+          content.includes('"eslint-plugin-sonarjs": "^4.1.0"')
+        )
+      ).toBe(true);
+      expect(
+        writtenContents.some((content) =>
+          content.includes('"typescript": "5.8.3"')
+        )
+      ).toBe(true);
     });
 
     test("installs oxlint-tsgolint when type-aware is true", async () => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -116,7 +116,8 @@
     "prettier-plugin-tailwindcss": "^0.8.0",
     "stylelint-config-idiomatic-order": "^10.0.0",
     "stylelint-config-standard": "^40.0.0",
-    "stylelint-prettier": "^5.0.3"
+    "stylelint-prettier": "^5.0.3",
+    "typescript": "5.8.3"
   },
   "peerDependencies": {
     "oxfmt": ">=0.1.0",

--- a/packages/cli/src/initialize.ts
+++ b/packages/cli/src/initialize.ts
@@ -191,12 +191,19 @@ const buildEslintDevDependencies = (
   return devDependencies;
 };
 
+const supportedSonarjsTypescriptVersion =
+  packageJson.devDependencies.typescript;
+
 // The generated oxlint config extends the github and sonarjs presets, which
 // run ESLint plugins via oxlint's JS plugin support — the plugins must be
 // installed in the target project for oxlint to resolve their specifiers.
 const oxlintJsPluginDevDependencies: Record<string, string> = {
   "eslint-plugin-github": packageJson.devDependencies["eslint-plugin-github"],
   "eslint-plugin-sonarjs": packageJson.devDependencies["eslint-plugin-sonarjs"],
+  // eslint-plugin-sonarjs depends on `typescript >=5`, which can resolve to
+  // TS builds whose CommonJS output throws during plugin loading. Keep
+  // JS-plugin loading on the last verified stable compiler build.
+  typescript: supportedSonarjsTypescriptVersion,
 };
 
 // Oxlint framework configs load the React Doctor rules via a JS plugin, which
@@ -275,7 +282,8 @@ const dependencyNamesByLinter: Record<Linter, Set<string>> = {
     "oxlint",
     "oxlint-plugin-react-doctor",
     "oxlint-tsgolint",
-    ...Object.keys(oxlintJsPluginDevDependencies),
+    "eslint-plugin-github",
+    "eslint-plugin-sonarjs",
   ]),
 };
 

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -55,9 +55,34 @@ export const readPackageJson = async (
 
 // -- Config files --
 
+export interface BiomeConfig {
+  extends?: string[];
+  [key: string]: unknown;
+}
+
+export interface TsConfig {
+  compilerOptions?: {
+    strict?: boolean;
+    strictNullChecks?: boolean;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+interface JsonSchema<T> {
+  safeParse: (value: unknown) =>
+    | {
+        data: T;
+        success: true;
+      }
+    | {
+        success: false;
+      };
+}
+
 export const biomeConfigSchema = z.looseObject({
   extends: z.array(z.string()).optional(),
-});
+}) as JsonSchema<BiomeConfig>;
 
 export const tsConfigSchema = z.looseObject({
   compilerOptions: z
@@ -66,11 +91,11 @@ export const tsConfigSchema = z.looseObject({
       strictNullChecks: z.boolean().optional(),
     })
     .optional(),
-});
+}) as JsonSchema<TsConfig>;
 
 export const parseJsonc = <T>(
   content: string,
-  schema: z.ZodType<T>
+  schema: JsonSchema<T>
 ): T | undefined => {
   const parsed = parse(content);
   const result = schema.safeParse(parsed);

--- a/packages/cli/src/tsconfig.ts
+++ b/packages/cli/src/tsconfig.ts
@@ -4,8 +4,8 @@ import { log } from "@clack/prompts";
 import { glob } from "glob";
 import { applyEdits, modify } from "jsonc-parser";
 import type { ModificationOptions } from "jsonc-parser";
-import type { z } from "zod";
 
+import type { TsConfig } from "./schemas";
 import { parseJsonc, tsConfigSchema } from "./schemas";
 import { writeProjectFile } from "./utils";
 
@@ -28,8 +28,6 @@ const findTsConfigFiles = async (): Promise<string[]> => {
     return [];
   }
 };
-
-type TsConfig = z.infer<typeof tsConfigSchema>;
 
 /**
  * Check if strictNullChecks is already enabled (directly or via strict: true)


### PR DESCRIPTION
Fixes #737.

This keeps the SonarJS oxlint preset enabled by default, but pins the TypeScript version used for JS plugin installs to `5.8.3`. `eslint-plugin-sonarjs` allows `typescript >=5`, which can resolve to TypeScript builds that throw while loading CJS output before Oxlint can run any rules.

What changed:

- add `typescript@5.8.3` to the Oxlint JS plugin dependency set during init
- source that version from `packages/cli/package.json`
- keep TypeScript out of stale-linter pruning so user TS deps are not removed during migration
- add coverage for install and skip-install init paths
- narrow JSON config schema typing so the package still typechecks under the pinned compiler

Validated locally:

- `bun test packages/cli/__tests__/initialize.test.ts`
- `bun test packages/cli/__tests__/oxlint.test.ts`
- `bun test packages/cli/__tests__/oxlint-config.test.ts`
- `bun run check`
- `bun run types`
- `bun run validate:configs`

The pre-commit hook also ran the full package test/check/types/config validation before the commit completed.
