### PR TITLE
fix: usage and setup links in the docs

### DIFF
--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -15,7 +15,7 @@ Install Ultracite quickly by running:
 npx ultracite init
 ```
 
-Then follow the [Usage](/usage) guide to get started, or check out [Setup](/setup) for more granular control.
+Then follow the [Usage](/docs/usage) guide to get started, or check out [Setup](/docs/setup) for more granular control.
 
 ## How does Ultracite work?
 


### PR DESCRIPTION
## Description

Usage and Setup links used to 404 due to missing -/docs/- in the url

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [ ] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

<img width="743" height="216" alt="Screenshot 2026-07-07 at 1 29 31 PM" src="https://github.com/user-attachments/assets/f127433d-a539-4d81-bcd8-d413e33c2204" />
