### PR TITLE
Removed react exclusive rule form core

### DIFF
--- a/.changeset/biome-no-unknown-attribute-react.md
+++ b/.changeset/biome-no-unknown-attribute-react.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Move Biome's `noUnknownAttribute` rule out of the core preset and into the `react` preset. The rule only recognises React's JSX attribute names, so projects using Solid, Svelte, Vue, or Qwik were incorrectly flagged for framework-standard attributes such as `class`.

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -507,7 +507,6 @@
         "noThenProperty": "error",
         "noTsIgnore": "error",
         "noUnassignedVariables": "error",
-        "noUnknownAttribute": "error",
         "noUnnecessaryConditions": "error",
         "noUnsafeDeclarationMerging": "error",
         "noUnsafeNegation": "error",

--- a/packages/cli/config/biome/react/biome.jsonc
+++ b/packages/cli/config/biome/react/biome.jsonc
@@ -19,6 +19,7 @@
 				"noLeakedRender": "error",
 				"noReactForwardRef": "error",
 				"noSuspiciousSemicolonInJsx": "error",
+				"noUnknownAttribute": "error",
 
 				"noReactSpecificProps": "off"
 			},


### PR DESCRIPTION
## Description

The [noUnknownAttribute](https://biomejs.dev/linter/rules/no-unknown-attribute/) is for react but is included in the core, when using project with solid i was getting errors for class


