### PR TITLE
fix: prefer Bun for bun lockfiles

### DIFF
--- a/.changeset/prefer-bun-lockfile.md
+++ b/.changeset/prefer-bun-lockfile.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Fix `init` selecting npm when a project contains `bun.lock`.

--- a/packages/cli/__tests__/initialize.test.ts
+++ b/packages/cli/__tests__/initialize.test.ts
@@ -24,6 +24,7 @@ import {
   upsertStylelintConfig,
   upsertTsConfig,
 } from "../src/initialize";
+import { preferBunPackageManager } from "../src/package-manager";
 
 const npmPm = { command: "npm", name: "npm" } as PackageManager;
 
@@ -594,6 +595,14 @@ describe("initialize", () => {
     expect(mockLog.info).toHaveBeenCalled();
   });
 
+  test("prefers Bun when nypm misdetects a Bun lockfile as npm", () => {
+    const detected = preferBunPackageManager(
+      { command: "npm", name: "npm" } as PackageManager,
+      true
+    );
+
+    expect(detected).toMatchObject({ command: "bun", name: "bun" });
+  });
   test("rejects unsupported explicit package managers before installing", async () => {
     const mockAddDep = mock(() => Promise.resolve());
 

--- a/packages/cli/src/initialize.ts
+++ b/packages/cli/src/initialize.ts
@@ -9,7 +9,7 @@ import {
   select,
   spinner,
 } from "@clack/prompts";
-import { addDevDependency, detectPackageManager } from "nypm";
+import { addDevDependency } from "nypm";
 import type { PackageManager, PackageManagerName } from "nypm";
 
 import packageJson from "../package.json" with { type: "json" };
@@ -36,6 +36,7 @@ import { prettier } from "./linters/prettier";
 import { stylelint } from "./linters/stylelint";
 import {
   assertSupportedPackageManagerName,
+  detectPackageManager,
   normalizePackageManager,
 } from "./package-manager";
 import { readPackageJson } from "./schemas";

--- a/packages/cli/src/package-manager.ts
+++ b/packages/cli/src/package-manager.ts
@@ -1,3 +1,7 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { detectPackageManager as detectNypmPackageManager } from "nypm";
 import type { PackageManager, PackageManagerName } from "nypm";
 
 const supportedPackageManagers = [
@@ -36,3 +40,24 @@ export const normalizePackageManager = (
     name,
   };
 };
+
+export const preferBunPackageManager = <T extends PackageManager | undefined>(
+  detected: T,
+  hasBunLockfile: boolean
+): T => {
+  if (detected?.name !== "npm" || !hasBunLockfile) {
+    return detected;
+  }
+
+  return {
+    ...detected,
+    command: "bun",
+    name: "bun",
+  } as T;
+};
+
+export const detectPackageManager = async (cwd: string) =>
+  preferBunPackageManager(
+    await detectNypmPackageManager(cwd),
+    existsSync(path.join(cwd, "bun.lock"))
+  );


### PR DESCRIPTION
## Summary

Fixes the `ultracite init` path that chooses npm for a Bun project with `bun.lock`.

## Root cause

When `nypm` reports npm while `bun.lock` is present, the initializer passed that result through to dependency installation. This can lead npm to emit an unrelated `ERESOLVE` error for an otherwise compatible dependency graph.

## Changes

- Prefer Bun for the specific npm-plus-`bun.lock` detection mismatch.
- Preserve normal nypm detection and explicit `--pm` selection.
- Add regression coverage for the preference decision.

## Validation

- `bun run build --filter ultracite`
- `bun run test` (424 passing)
- `bun run check`
- `bun run types`
- `bun run validate:configs`

Closes #754