### PR TITLE
Fix Biome useSortedPackageJson action not being executed

### DIFF
--- a/.changeset/fix-use-sorted-package-json.md
+++ b/.changeset/fix-use-sorted-package-json.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Fix the useSortedPackageJson action not being executed by turning on assist actions for package.json-like files.

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -715,6 +715,14 @@
     {
       // Package.json and similar JSON config files
       "includes": ["**/package.json", ".github/**/*.json"],
+      "assist": {
+        "enabled": true,
+        "actions": {
+          "source": {
+            "useSortedKeys": "off"
+          }
+        }
+      },
       "json": {
         "parser": {
           "allowTrailingCommas": true


### PR DESCRIPTION
## Description

In the Biome core config, the `useSortedPackageJson` action has been explicitly enabled but has no effect because the assist actions remain turned off for JSON files. This PR fixes that by turning on assist actions for `package.json`-like files and explicitly disables the `useSortedKeys` action to prevent conflicts.

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Additional Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package and GitHub JSON files now receive the appropriate assist actions.
  * Sorting assistance for package metadata files works correctly without affecting other JSON and JSONC behavior.

* **Documentation**
  * Added release documentation for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->