### PR TITLE
fix: ignore .alchemy directory across linters and formatters

### DIFF
--- a/.changeset/ignore-alchemy-directory.md
+++ b/.changeset/ignore-alchemy-directory.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Ignore `.alchemy` across all linters and formatters. Alchemy (alchemy.run) writes local state and generated bindings to a `.alchemy` directory. It is now part of the shared ignore patterns synced into Biome's `files.includes` and imported by oxlint, oxfmt, and ESLint, and the Stylelint preset ignores it via `ignoreFiles`. Prettier needs no change: it already respects `.gitignore`/`.prettierignore`.

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -26,6 +26,7 @@
       "!!**/.netlify",
       "!!**/.wrangler",
       "!!**/.wrangler-dry-run",
+      "!!**/.alchemy",
       "!!**/.docusaurus",
       "!!**/.cache",
       "!!**/.parcel-cache",

--- a/packages/cli/config/shared/ignores.mjs
+++ b/packages/cli/config/shared/ignores.mjs
@@ -29,6 +29,8 @@ export const ignorePatterns = [
   "**/.netlify",
   "**/.wrangler",
   "**/.wrangler-dry-run",
+  // Alchemy (alchemy.run) stores local state and generated bindings here
+  "**/.alchemy",
   "**/.docusaurus",
   "**/.cache",
   "**/.parcel-cache",

--- a/packages/cli/config/shared/ignores.mjs
+++ b/packages/cli/config/shared/ignores.mjs
@@ -29,7 +29,6 @@ export const ignorePatterns = [
   "**/.netlify",
   "**/.wrangler",
   "**/.wrangler-dry-run",
-  // Alchemy (alchemy.run) stores local state and generated bindings here
   "**/.alchemy",
   "**/.docusaurus",
   "**/.cache",

--- a/packages/cli/config/stylelint/stylelint.config.mjs
+++ b/packages/cli/config/stylelint/stylelint.config.mjs
@@ -2,9 +2,6 @@
 const config = {
   extends: ["stylelint-config-standard", "stylelint-config-idiomatic-order"],
   plugins: ["stylelint-prettier"],
-  // Alchemy (alchemy.run) writes local state and generated bindings to a
-  // .alchemy directory; keep it out of stylelint runs.
-  ignoreFiles: ["**/.alchemy/**"],
   rules: {
     "at-rule-no-unknown": [
       true,

--- a/packages/cli/config/stylelint/stylelint.config.mjs
+++ b/packages/cli/config/stylelint/stylelint.config.mjs
@@ -2,6 +2,9 @@
 const config = {
   extends: ["stylelint-config-standard", "stylelint-config-idiomatic-order"],
   plugins: ["stylelint-prettier"],
+  // Alchemy (alchemy.run) writes local state and generated bindings to a
+  // .alchemy directory; keep it out of stylelint runs.
+  ignoreFiles: ["**/.alchemy/**"],
   rules: {
     "at-rule-no-unknown": [
       true,


### PR DESCRIPTION
Closes #776

## What

- Adds `**/.alchemy` to `config/shared/ignores.mjs`, the single source of truth that the prebuild syncs into Biome's `files.includes` and that oxlint, oxfmt, and ESLint import directly.
- Adds `ignoreFiles: ["**/.alchemy/**"]` to the Stylelint preset, which doesn't consume the shared patterns.
- Regenerates `biome/core/biome.jsonc` via `scripts/generate-dts.ts`.
- Patch changeset included.

Prettier needs no change: it has no config-level ignore option and already resolves ignores from `.gitignore` / `.prettierignore`.

## Verification

- `bun run scripts/generate-dts.ts` regenerates the biome includes cleanly
- `bun scripts/validate-biome.ts`: all 15 configs valid
- `bun run types`: passes
- Test suite: 507 passing. The 6 failures in `spawn-sync.test.ts` are pre-existing Windows-only issues (SIGKILL/ENOENT semantics differ from Linux/macOS) and reproduce on a clean checkout of `main`; CI runs on Ubuntu where they pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated formatting and linting configurations to ignore `.alchemy` directories.
  - Prevented local state and generated bindings from being included in code-quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->