### PR TITLE
fix: add vitest typecheck files to configs

### DIFF
--- a/.changeset/rare-kings-hope.md
+++ b/.changeset/rare-kings-hope.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+Add Vitest type test files (\*.test-d.ts) to the globs for lint rules related to testing.

--- a/.changeset/rare-kings-hope.md
+++ b/.changeset/rare-kings-hope.md
@@ -2,4 +2,4 @@
 "ultracite": patch
 ---
 
-Add Vitest type test files (\*.test-d.ts) to the globs for lint rules related to testing.
+Add Vitest type-test files (`**/*.{test-d,spec-d}.{ts,tsx,js,jsx}`) to the test-file globs so the shared test relaxations and the Vitest rule overrides apply to them, and enable the Vitest plugin's `typecheck` setting in the ESLint preset so `expectTypeOf`/`assertType` count as assertions.

--- a/packages/cli/__tests__/oxlint-config.test.ts
+++ b/packages/cli/__tests__/oxlint-config.test.ts
@@ -723,3 +723,78 @@ describe("oxlint next config", () => {
     ).toEqual([]);
   });
 });
+
+describe("test file globs", () => {
+  const TEST_FILE_GLOB = "**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}";
+  const TESTS_DIR_GLOB = "**/__tests__/**/*.{ts,tsx,js,jsx}";
+
+  interface FilesEntry {
+    files?: string[];
+  }
+
+  const readEslintConfig = async (name: string) => {
+    const configPath = path.join(
+      import.meta.dirname,
+      `../config/eslint/${name}/eslint.config.mjs`
+    );
+    const mod = await import(configPath);
+    // SAFETY: every eslint preset in config/eslint exports a flat-config array.
+    return mod.default as FilesEntry[];
+  };
+
+  const findTestOverride = (entries: FilesEntry[] | undefined) =>
+    entries?.find((entry) => entry.files?.includes(TESTS_DIR_GLOB));
+
+  test("oxlint core, js-plugins and vitest share the same test file glob", async () => {
+    const names = ["core", "js-plugins", "vitest"];
+    const configs = await Promise.all(names.map(readOxlintConfig));
+
+    for (const [index, config] of configs.entries()) {
+      const name = names[index];
+      const override = findTestOverride(config.overrides);
+
+      expect(
+        override,
+        `${name} should have a test file override`
+      ).toBeDefined();
+      expect(override?.files, `${name} test file glob`).toContain(
+        TEST_FILE_GLOB
+      );
+    }
+  });
+
+  test("eslint core and vitest share the same test file glob", () => {
+    // Read as text rather than importing: the core preset pulls in plugins
+    // that touch node:fs at import time, which other test files mock.
+    for (const name of ["core", "vitest"]) {
+      const configPath = path.join(
+        import.meta.dirname,
+        `../config/eslint/${name}/eslint.config.mjs`
+      );
+      const source = readFileSync(configPath, "utf-8");
+
+      expect(source, `${name} test file glob`).toContain(`"${TEST_FILE_GLOB}"`);
+    }
+  });
+
+  test("biome core relaxes rules for type-test files", () => {
+    const biomePath = path.join(
+      import.meta.dirname,
+      "../config/biome/core/biome.jsonc"
+    );
+    const biome = readFileSync(biomePath, "utf-8");
+
+    expect(biome).toContain(`"${TEST_FILE_GLOB}"`);
+  });
+
+  test("eslint vitest enables typecheck so expectTypeOf counts as an assertion", async () => {
+    const config = await readEslintConfig("vitest");
+    // SAFETY: the vitest preset's test override is a flat-config entry, which
+    // may carry a `settings` block alongside `files`.
+    const override = findTestOverride(config) as
+      | { settings?: { vitest?: { typecheck?: boolean } } }
+      | undefined;
+
+    expect(override?.settings?.vitest?.typecheck).toBe(true);
+  });
+});

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -638,7 +638,7 @@
     },
     {
       // Test files
-      "includes": ["**/*.{test,spec}.{ts,tsx,js,jsx}", "**/__tests__/**/*"],
+      "includes": ["**/*.{test,spec,test-d}.{ts,tsx,js,jsx}", "**/__tests__/**/*"],
       "linter": {
         "rules": {
           "complexity": {

--- a/packages/cli/config/biome/core/biome.jsonc
+++ b/packages/cli/config/biome/core/biome.jsonc
@@ -638,7 +638,7 @@
     },
     {
       // Test files
-      "includes": ["**/*.{test,spec,test-d}.{ts,tsx,js,jsx}", "**/__tests__/**/*"],
+      "includes": ["**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}", "**/__tests__/**/*"],
       "linter": {
         "rules": {
           "complexity": {

--- a/packages/cli/config/eslint/core/eslint.config.mjs
+++ b/packages/cli/config/eslint/core/eslint.config.mjs
@@ -156,7 +156,7 @@ const config = [
     // Repeated string literals (test titles, expected values) are normal and
     // idiomatic in test files. Mirrors the oxlint core test override.
     files: [
-      "**/*.{test,spec}.{ts,tsx,js,jsx}",
+      "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
       "**/__tests__/**/*.{ts,tsx,js,jsx}",
     ],
     rules: {

--- a/packages/cli/config/eslint/core/eslint.config.mjs
+++ b/packages/cli/config/eslint/core/eslint.config.mjs
@@ -156,7 +156,7 @@ const config = [
     // Repeated string literals (test titles, expected values) are normal and
     // idiomatic in test files. Mirrors the oxlint core test override.
     files: [
-      "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
+      "**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}",
       "**/__tests__/**/*.{ts,tsx,js,jsx}",
     ],
     rules: {

--- a/packages/cli/config/eslint/jest/eslint.config.mjs
+++ b/packages/cli/config/eslint/jest/eslint.config.mjs
@@ -7,6 +7,8 @@ import jestRules from "./rules/jest.mjs";
 
 const config = [
   {
+    // Vitest type-test files (*.test-d.ts, *.spec-d.ts) are intentionally
+    // excluded — Jest has no typecheck mode, so its rules don't apply to them.
     files: [
       "**/*.{test,spec}.{ts,tsx,js,jsx}",
       "**/__tests__/**/*.{ts,tsx,js,jsx}",

--- a/packages/cli/config/eslint/vitest/eslint.config.mjs
+++ b/packages/cli/config/eslint/vitest/eslint.config.mjs
@@ -7,7 +7,7 @@ import vitestRules from "./rules/vitest.mjs";
 const config = [
   {
     files: [
-      "**/*.{test,spec}.{ts,tsx,js,jsx}",
+      "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
       "**/__tests__/**/*.{ts,tsx,js,jsx}",
     ],
     plugins: {

--- a/packages/cli/config/eslint/vitest/eslint.config.mjs
+++ b/packages/cli/config/eslint/vitest/eslint.config.mjs
@@ -7,7 +7,7 @@ import vitestRules from "./rules/vitest.mjs";
 const config = [
   {
     files: [
-      "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
+      "**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}",
       "**/__tests__/**/*.{ts,tsx,js,jsx}",
     ],
     plugins: {
@@ -19,6 +19,14 @@ const config = [
       "no-empty-function": "off",
       // Mock factories use Promise.resolve/reject (conflicts with require-await)
       "promise/prefer-await-to-then": "off",
+    },
+    settings: {
+      vitest: {
+        // Teach expect-expect / valid-expect about expectTypeOf and assertType
+        // so type-test files (*.test-d.ts, *.spec-d.ts) are not flagged as
+        // having no assertions.
+        typecheck: true,
+      },
     },
   },
 ];

--- a/packages/cli/config/oxlint/core/index.mjs
+++ b/packages/cli/config/oxlint/core/index.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
       // Shared test file overrides — framework-specific test rules
       // are in separate jest/ and vitest/ configs to avoid conflicts.
       files: [
-        "**/*.{test,spec}.{ts,tsx,js,jsx}",
+        "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
       rules: {

--- a/packages/cli/config/oxlint/core/index.mjs
+++ b/packages/cli/config/oxlint/core/index.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
       // Shared test file overrides — framework-specific test rules
       // are in separate jest/ and vitest/ configs to avoid conflicts.
       files: [
-        "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
+        "**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
       rules: {

--- a/packages/cli/config/oxlint/jest/index.mjs
+++ b/packages/cli/config/oxlint/jest/index.mjs
@@ -3,6 +3,8 @@ import { defineConfig } from "oxlint";
 export default defineConfig({
   overrides: [
     {
+      // Vitest type-test files (*.test-d.ts, *.spec-d.ts) are intentionally
+      // excluded — Jest has no typecheck mode, so its rules don't apply to them.
       files: [
         "**/*.{test,spec}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",

--- a/packages/cli/config/oxlint/js-plugins/index.mjs
+++ b/packages/cli/config/oxlint/js-plugins/index.mjs
@@ -67,7 +67,7 @@ const config = defineConfig({
   overrides: [
     {
       files: [
-        "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
+        "**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
       rules: {

--- a/packages/cli/config/oxlint/js-plugins/index.mjs
+++ b/packages/cli/config/oxlint/js-plugins/index.mjs
@@ -67,7 +67,7 @@ const config = defineConfig({
   overrides: [
     {
       files: [
-        "**/*.{test,spec}.{ts,tsx,js,jsx}",
+        "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
       rules: {

--- a/packages/cli/config/oxlint/vitest/index.mjs
+++ b/packages/cli/config/oxlint/vitest/index.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   overrides: [
     {
       files: [
-        "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
+        "**/*.{test,spec,test-d,spec-d}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
       plugins: ["vitest"],

--- a/packages/cli/config/oxlint/vitest/index.mjs
+++ b/packages/cli/config/oxlint/vitest/index.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   overrides: [
     {
       files: [
-        "**/*.{test,spec}.{ts,tsx,js,jsx}",
+        "**/*.{test,spec,test-d}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
       ],
       plugins: ["vitest"],


### PR DESCRIPTION
## Description

add [vitest typecheck](https://vitest.dev/guide/testing-types) files to the vitest related file globs

## Checklist

- [x] I've reviewed my code
- [ ] ~I've written tests~
- [x] I've generated a change set file
- [ ] ~I've updated the docs, if necessary~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for Vitest type-test files using `.test-d` and `.spec-d` naming patterns across supported linting configurations.
  * Ensured type assertions such as `expectTypeOf` and `assertType` are recognized as valid test assertions.
  * Preserved appropriate handling for Jest configurations, where Vitest type-checking does not apply.

* **Documentation**
  * Added release notes documenting expanded type-test file support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->