### PR TITLE
fix(cli): run lint fixes before the formatter in `ultracite fix`

### DIFF
--- a/.changeset/lint-before-format.md
+++ b/.changeset/lint-before-format.md
@@ -1,0 +1,5 @@
+---
+"ultracite": patch
+---
+
+`ultracite fix` now runs the linter's fixes before the formatter (oxlint before oxfmt, ESLint before Prettier). A fixer can insert unformatted code, such as the braces `curly` adds or the imports `consistent-type-specifier-style` splits, and running the formatter first left that code unformatted until the next run. One `fix` is now idempotent.

--- a/.changeset/lint-before-format.md
+++ b/.changeset/lint-before-format.md
@@ -2,4 +2,6 @@
 "ultracite": patch
 ---
 
-`ultracite fix` now runs the linter's fixes before the formatter (oxlint before oxfmt, ESLint before Prettier). A fixer can insert unformatted code, such as the braces `curly` adds or the imports `consistent-type-specifier-style` splits, and running the formatter first left that code unformatted until the next run. One `fix` is now idempotent.
+`ultracite fix` now runs lint fixes before the formatter: oxlint before oxfmt, and ESLint then Stylelint before Prettier. A fixer can insert unformatted code, such as the braces `curly` adds, the imports `consistent-type-specifier-style` splits, or the font names Stylelint requotes, and running the formatter first left that code unformatted until the next run. Fixer-inserted code is now formatted in the same run. The `--claude` and `--codex` agent passes follow the same order.
+
+`unicorn/no-nested-ternary` is now off in the oxlint and ESLint presets: its fixer adds parentheses that oxfmt and Prettier remove, so the two tools rewrote the file on every run. The core `no-nested-ternary` rule still reports nested ternaries.

--- a/packages/cli/__tests__/agent-fix-linters.test.ts
+++ b/packages/cli/__tests__/agent-fix-linters.test.ts
@@ -54,7 +54,7 @@ describe("agent-fix linter adapters", () => {
     mock.restore();
   });
 
-  test("oxlint adapter runs oxlint --fix with JSON output then oxfmt and parses diagnostics", () => {
+  test("oxlint adapter runs oxlint --fix, oxfmt, then a report-only oxlint pass and parses its diagnostics", () => {
     const mockSpawn = mock((cmd: string, _args: string[]) => ({
       status: cmd === "oxlint" ? 1 : 0,
       stdout: cmd === "oxlint" ? oxlintJson : "",
@@ -63,11 +63,13 @@ describe("agent-fix linter adapters", () => {
 
     const diagnostics = getLinterAdapter("oxlint").fixAndCollect([], []);
 
-    const [oxlintCall, oxfmtCall] = mockSpawn.mock.calls;
-    expect(oxlintCall[0]).toBe("oxlint");
-    expect(oxlintCall[1]).toEqual(["--fix", "-f", "json", "."]);
+    const [fixCall, oxfmtCall, collectCall] = mockSpawn.mock.calls;
+    expect(fixCall[0]).toBe("oxlint");
+    expect(fixCall[1]).toEqual(["--fix", "."]);
     expect(oxfmtCall[0]).toBe("oxfmt");
     expect(oxfmtCall[1]).toEqual(["--write", "."]);
+    expect(collectCall[0]).toBe("oxlint");
+    expect(collectCall[1]).toEqual(["-f", "json", "."]);
 
     expect(diagnostics).toEqual([
       {
@@ -96,11 +98,12 @@ describe("agent-fix linter adapters", () => {
       ["--unsafe", "--type-aware"]
     );
 
-    const [oxlintCall] = mockSpawn.mock.calls;
-    expect(oxlintCall[1]).toContain("--fix-dangerously");
-    expect(oxlintCall[1]).not.toContain("--unsafe");
-    expect(oxlintCall[1]).toContain("--type-aware");
-    expect(oxlintCall[1]).toContain("src/a.ts");
+    const [fixCall, , collectCall] = mockSpawn.mock.calls;
+    expect(fixCall[1]).toContain("--fix-dangerously");
+    expect(fixCall[1]).not.toContain("--unsafe");
+    expect(fixCall[1]).toContain("--type-aware");
+    expect(fixCall[1]).toContain("src/a.ts");
+    expect(collectCall[1]).toEqual(["--type-aware", "-f", "json", "src/a.ts"]);
   });
 
   test("oxlint adapter verify targets the single file", () => {
@@ -112,9 +115,10 @@ describe("agent-fix linter adapters", () => {
 
     getLinterAdapter("oxlint").verify("src/a.ts", []);
 
-    const [oxlintCall, oxfmtCall] = mockSpawn.mock.calls;
-    expect(oxlintCall[1]).toEqual(["--fix", "-f", "json", "src/a.ts"]);
+    const [fixCall, oxfmtCall, collectCall] = mockSpawn.mock.calls;
+    expect(fixCall[1]).toEqual(["--fix", "src/a.ts"]);
     expect(oxfmtCall[1]).toEqual(["--write", "src/a.ts"]);
+    expect(collectCall[1]).toEqual(["-f", "json", "src/a.ts"]);
   });
 
   test("oxlint adapter throws on spawn failure", () => {
@@ -192,7 +196,7 @@ describe("agent-fix linter adapters", () => {
     expect(diagnostic.column).toBe(1);
   });
 
-  test("eslint adapter runs eslint --fix with JSON, stylelint autofix, then prettier", () => {
+  test("eslint adapter runs eslint --fix, stylelint, prettier, then a report-only eslint pass", () => {
     const mockSpawn = mock((cmd: string, _args: string[]) => ({
       status: 0,
       stdout: cmd === "eslint" ? eslintJson : "",
@@ -202,10 +206,12 @@ describe("agent-fix linter adapters", () => {
     const diagnostics = getLinterAdapter("eslint").fixAndCollect([], []);
 
     const commands = mockSpawn.mock.calls.map((call) => call[0]);
-    expect(commands).toEqual(["eslint", "stylelint", "prettier"]);
+    expect(commands).toEqual(["eslint", "stylelint", "prettier", "eslint"]);
 
-    const [eslintCall] = mockSpawn.mock.calls;
-    expect(eslintCall[1]).toEqual(["--fix", "-f", "json", "."]);
+    const [fixCall] = mockSpawn.mock.calls;
+    const collectCall = mockSpawn.mock.calls.at(-1);
+    expect(fixCall[1]).toEqual(["--fix", "."]);
+    expect(collectCall?.[1]).toEqual(["-f", "json", "."]);
 
     expect(diagnostics).toEqual([
       {
@@ -230,6 +236,6 @@ describe("agent-fix linter adapters", () => {
     getLinterAdapter("eslint").verify("src/a.ts", []);
 
     const commands = mockSpawn.mock.calls.map((call) => call[0]);
-    expect(commands).toEqual(["eslint", "prettier"]);
+    expect(commands).toEqual(["eslint", "prettier", "eslint"]);
   });
 });

--- a/packages/cli/__tests__/agent-fix-linters.test.ts
+++ b/packages/cli/__tests__/agent-fix-linters.test.ts
@@ -54,7 +54,7 @@ describe("agent-fix linter adapters", () => {
     mock.restore();
   });
 
-  test("oxlint adapter runs oxfmt then oxlint --fix with JSON output and parses diagnostics", () => {
+  test("oxlint adapter runs oxlint --fix with JSON output then oxfmt and parses diagnostics", () => {
     const mockSpawn = mock((cmd: string, _args: string[]) => ({
       status: cmd === "oxlint" ? 1 : 0,
       stdout: cmd === "oxlint" ? oxlintJson : "",
@@ -63,11 +63,11 @@ describe("agent-fix linter adapters", () => {
 
     const diagnostics = getLinterAdapter("oxlint").fixAndCollect([], []);
 
-    const [oxfmtCall, oxlintCall] = mockSpawn.mock.calls;
-    expect(oxfmtCall[0]).toBe("oxfmt");
-    expect(oxfmtCall[1]).toEqual(["--write", "."]);
+    const [oxlintCall, oxfmtCall] = mockSpawn.mock.calls;
     expect(oxlintCall[0]).toBe("oxlint");
     expect(oxlintCall[1]).toEqual(["--fix", "-f", "json", "."]);
+    expect(oxfmtCall[0]).toBe("oxfmt");
+    expect(oxfmtCall[1]).toEqual(["--write", "."]);
 
     expect(diagnostics).toEqual([
       {
@@ -96,7 +96,7 @@ describe("agent-fix linter adapters", () => {
       ["--unsafe", "--type-aware"]
     );
 
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toContain("--fix-dangerously");
     expect(oxlintCall[1]).not.toContain("--unsafe");
     expect(oxlintCall[1]).toContain("--type-aware");
@@ -112,9 +112,9 @@ describe("agent-fix linter adapters", () => {
 
     getLinterAdapter("oxlint").verify("src/a.ts", []);
 
-    const [oxfmtCall, oxlintCall] = mockSpawn.mock.calls;
-    expect(oxfmtCall[1]).toEqual(["--write", "src/a.ts"]);
+    const [oxlintCall, oxfmtCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toEqual(["--fix", "-f", "json", "src/a.ts"]);
+    expect(oxfmtCall[1]).toEqual(["--write", "src/a.ts"]);
   });
 
   test("oxlint adapter throws on spawn failure", () => {
@@ -122,7 +122,7 @@ describe("agent-fix linter adapters", () => {
     mock.module("../src/spawn-sync", () => ({ spawnSync: mockSpawn }));
 
     expect(() => getLinterAdapter("oxlint").fixAndCollect([], [])).toThrow(
-      "Failed to run oxfmt: spawn failed"
+      "Failed to run oxlint: spawn failed"
     );
   });
 
@@ -192,7 +192,7 @@ describe("agent-fix linter adapters", () => {
     expect(diagnostic.column).toBe(1);
   });
 
-  test("eslint adapter runs prettier, eslint --fix with JSON, and stylelint autofix", () => {
+  test("eslint adapter runs eslint --fix with JSON, stylelint autofix, then prettier", () => {
     const mockSpawn = mock((cmd: string, _args: string[]) => ({
       status: 0,
       stdout: cmd === "eslint" ? eslintJson : "",
@@ -202,9 +202,9 @@ describe("agent-fix linter adapters", () => {
     const diagnostics = getLinterAdapter("eslint").fixAndCollect([], []);
 
     const commands = mockSpawn.mock.calls.map((call) => call[0]);
-    expect(commands).toEqual(["prettier", "eslint", "stylelint"]);
+    expect(commands).toEqual(["eslint", "stylelint", "prettier"]);
 
-    const [, eslintCall] = mockSpawn.mock.calls;
+    const [eslintCall] = mockSpawn.mock.calls;
     expect(eslintCall[1]).toEqual(["--fix", "-f", "json", "."]);
 
     expect(diagnostics).toEqual([
@@ -230,6 +230,6 @@ describe("agent-fix linter adapters", () => {
     getLinterAdapter("eslint").verify("src/a.ts", []);
 
     const commands = mockSpawn.mock.calls.map((call) => call[0]);
-    expect(commands).toEqual(["prettier", "eslint"]);
+    expect(commands).toEqual(["eslint", "prettier"]);
   });
 });

--- a/packages/cli/__tests__/fix.test.ts
+++ b/packages/cli/__tests__/fix.test.ts
@@ -220,7 +220,7 @@ describe("fix", () => {
     expect(() => fix([])).toThrow("No linter configuration found");
   });
 
-  test("runs eslint fix when linter is eslint (runs prettier, eslint, stylelint)", () => {
+  test("runs eslint fix when linter is eslint (runs eslint, prettier, stylelint)", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
         status: 0,
@@ -236,11 +236,11 @@ describe("fix", () => {
     fix([]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const [prettierCall, eslintCall, stylelintCall] = mockSpawn.mock.calls;
-    expect(prettierCall[0]).toBe("prettier");
-    expect(prettierCall[1]).toContain("--write");
+    const [eslintCall, prettierCall, stylelintCall] = mockSpawn.mock.calls;
     expect(eslintCall[0]).toBe("eslint");
     expect(eslintCall[1]).toContain("--fix");
+    expect(prettierCall[0]).toBe("prettier");
+    expect(prettierCall[1]).toContain("--write");
     expect(stylelintCall[0]).toBe("stylelint");
     expect(stylelintCall[1]).toContain("--fix");
   });
@@ -262,7 +262,7 @@ describe("fix", () => {
 
     // stylelint is skipped because no CSS-like targets remain after filtering
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, eslintCall] = mockSpawn.mock.calls;
+    const [eslintCall] = mockSpawn.mock.calls;
     expect(eslintCall[1]).toContain("src/index.ts");
   });
 
@@ -282,9 +282,9 @@ describe("fix", () => {
     fix(["src/styles.css", "src/index.ts", "lib"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const [prettierCall, eslintCall, stylelintCall] = mockSpawn.mock.calls;
-    expect(prettierCall[0]).toBe("prettier");
+    const [eslintCall, prettierCall, stylelintCall] = mockSpawn.mock.calls;
     expect(eslintCall[0]).toBe("eslint");
+    expect(prettierCall[0]).toBe("prettier");
     expect(stylelintCall[0]).toBe("stylelint");
     expect(stylelintCall[1]).toContain("--fix");
     expect(stylelintCall[1]).toContain("--allow-empty-input");
@@ -293,7 +293,7 @@ describe("fix", () => {
     expect(stylelintCall[1]).not.toContain("src/index.ts");
   });
 
-  test("eslint fix throws LinterExitError when prettier fails", () => {
+  test("eslint fix throws LinterExitError when eslint fails", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
         status: 1,
@@ -307,13 +307,13 @@ describe("fix", () => {
       detectLinter: mock(() => "eslint"),
     }));
 
-    expect(() => fix([])).toThrow("Prettier exited with code 1");
+    expect(() => fix([])).toThrow("ESLint exited with code 1");
   });
 
-  test("eslint fix throws on prettier spawn error", () => {
+  test("eslint fix throws on eslint spawn error when it is the first step", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
-        error: new Error("prettier spawn failed"),
+        error: new Error("eslint spawn failed"),
         status: null,
       })
     );
@@ -325,22 +325,20 @@ describe("fix", () => {
       detectLinter: mock(() => "eslint"),
     }));
 
-    expect(() => fix([])).toThrow(
-      "Failed to run Prettier: prettier spawn failed"
-    );
+    expect(() => fix([])).toThrow("Failed to run ESLint: eslint spawn failed");
   });
 
-  test("eslint fix throws on eslint spawn error", () => {
+  test("eslint fix throws on prettier spawn error", () => {
     let callCount = 0;
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => {
         callCount += 1;
-        // prettier succeeds
+        // eslint succeeds
         if (callCount === 1) {
           return { status: 0 };
         }
         return {
-          error: new Error("eslint spawn failed"),
+          error: new Error("prettier spawn failed"),
           status: null,
         };
       }
@@ -353,7 +351,9 @@ describe("fix", () => {
       detectLinter: mock(() => "eslint"),
     }));
 
-    expect(() => fix([])).toThrow("Failed to run ESLint: eslint spawn failed");
+    expect(() => fix([])).toThrow(
+      "Failed to run Prettier: prettier spawn failed"
+    );
   });
 
   test("eslint fix throws on stylelint spawn error", () => {
@@ -384,7 +384,7 @@ describe("fix", () => {
     );
   });
 
-  test("runs oxlint fix when linter is oxlint (runs oxfmt, oxlint)", () => {
+  test("runs oxlint fix when linter is oxlint (runs oxlint, oxfmt)", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
         status: 0,
@@ -400,11 +400,11 @@ describe("fix", () => {
     fix([]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [oxfmtCall, oxlintCall] = mockSpawn.mock.calls;
-    expect(oxfmtCall[0]).toBe("oxfmt");
-    expect(oxfmtCall[1]).toContain("--write");
+    const [oxlintCall, oxfmtCall] = mockSpawn.mock.calls;
     expect(oxlintCall[0]).toBe("oxlint");
     expect(oxlintCall[1]).toContain("--fix");
+    expect(oxfmtCall[0]).toBe("oxfmt");
+    expect(oxfmtCall[1]).toContain("--write");
   });
 
   test("runs oxlint fix with specific files", () => {
@@ -423,14 +423,14 @@ describe("fix", () => {
     fix(["src/index.ts"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toContain("src/index.ts");
   });
 
   test("oxlint fix throws on spawn error", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
-        error: new Error("oxfmt spawn failed"),
+        error: new Error("oxlint spawn failed"),
         status: null,
       })
     );
@@ -442,7 +442,7 @@ describe("fix", () => {
       detectLinter: mock(() => "oxlint"),
     }));
 
-    expect(() => fix([])).toThrow("Failed to run oxfmt: oxfmt spawn failed");
+    expect(() => fix([])).toThrow("Failed to run Oxlint: oxlint spawn failed");
   });
 
   test("oxlint fix throws LinterExitError on failure", () => {
@@ -459,7 +459,7 @@ describe("fix", () => {
       detectLinter: mock(() => "oxlint"),
     }));
 
-    expect(() => fix([])).toThrow("oxfmt exited with code 1");
+    expect(() => fix([])).toThrow("Oxlint exited with code 1");
   });
 
   test("passes through --type-aware flag to oxlint", () => {
@@ -478,7 +478,7 @@ describe("fix", () => {
     fix([], ["--type-aware"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toContain("--type-aware");
   });
 
@@ -498,7 +498,7 @@ describe("fix", () => {
     fix([], ["--type-check"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toContain("--type-check");
   });
 
@@ -518,7 +518,7 @@ describe("fix", () => {
     fix([], ["--type-aware", "--type-check"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toContain("--type-aware");
     expect(oxlintCall[1]).toContain("--type-check");
   });
@@ -539,7 +539,7 @@ describe("fix", () => {
     fix([], []);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).not.toContain("--type-aware");
     expect(oxlintCall[1]).not.toContain("--type-check");
   });
@@ -560,7 +560,7 @@ describe("fix", () => {
     fix([], ["--unsafe"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[1]).toContain("--fix-dangerously");
     expect(oxlintCall[1]).not.toContain("--unsafe");
   });
@@ -583,7 +583,7 @@ describe("fix", () => {
 
     expect(() => fix([])).toThrow("oxfmt exited with code 1");
     expect(mockSpawn).toHaveBeenCalledTimes(2);
-    const [, oxlintCall] = mockSpawn.mock.calls;
+    const [oxlintCall] = mockSpawn.mock.calls;
     expect(oxlintCall[0]).toBe("oxlint");
   });
 
@@ -605,7 +605,7 @@ describe("fix", () => {
 
     expect(() => fix([])).toThrow("Prettier exited with code 1");
     expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const [, eslintCall, stylelintCall] = mockSpawn.mock.calls;
+    const [eslintCall, , stylelintCall] = mockSpawn.mock.calls;
     expect(eslintCall[0]).toBe("eslint");
     expect(stylelintCall[0]).toBe("stylelint");
   });

--- a/packages/cli/__tests__/fix.test.ts
+++ b/packages/cli/__tests__/fix.test.ts
@@ -220,7 +220,7 @@ describe("fix", () => {
     expect(() => fix([])).toThrow("No linter configuration found");
   });
 
-  test("runs eslint fix when linter is eslint (runs eslint, prettier, stylelint)", () => {
+  test("runs eslint fix when linter is eslint (runs eslint, stylelint, prettier)", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
         status: 0,
@@ -236,13 +236,13 @@ describe("fix", () => {
     fix([]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const [eslintCall, prettierCall, stylelintCall] = mockSpawn.mock.calls;
+    const [eslintCall, stylelintCall, prettierCall] = mockSpawn.mock.calls;
     expect(eslintCall[0]).toBe("eslint");
     expect(eslintCall[1]).toContain("--fix");
-    expect(prettierCall[0]).toBe("prettier");
-    expect(prettierCall[1]).toContain("--write");
     expect(stylelintCall[0]).toBe("stylelint");
     expect(stylelintCall[1]).toContain("--fix");
+    expect(prettierCall[0]).toBe("prettier");
+    expect(prettierCall[1]).toContain("--write");
   });
 
   test("runs eslint fix with specific files", () => {
@@ -282,10 +282,10 @@ describe("fix", () => {
     fix(["src/styles.css", "src/index.ts", "lib"]);
 
     expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const [eslintCall, prettierCall, stylelintCall] = mockSpawn.mock.calls;
+    const [eslintCall, stylelintCall, prettierCall] = mockSpawn.mock.calls;
     expect(eslintCall[0]).toBe("eslint");
-    expect(prettierCall[0]).toBe("prettier");
     expect(stylelintCall[0]).toBe("stylelint");
+    expect(prettierCall[0]).toBe("prettier");
     expect(stylelintCall[1]).toContain("--fix");
     expect(stylelintCall[1]).toContain("--allow-empty-input");
     expect(stylelintCall[1]).toContain("src/styles.css");
@@ -308,6 +308,26 @@ describe("fix", () => {
     }));
 
     expect(() => fix([])).toThrow("ESLint exited with code 1");
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+  });
+
+  test("eslint fix still runs stylelint and prettier when eslint exits non-zero", () => {
+    const mockSpawn = mock(
+      (cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
+        status: cmd === "eslint" ? 1 : 0,
+      })
+    );
+    mock.module("../src/spawn-sync", () => ({
+      spawnSync: mockSpawn,
+    }));
+    mock.module("../src/utils", () => ({
+      detectLinter: mock(() => "eslint"),
+    }));
+
+    expect(() => fix([])).toThrow("ESLint exited with code 1");
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+    const commands = mockSpawn.mock.calls.map((call) => call[0]);
+    expect(commands).toEqual(["eslint", "stylelint", "prettier"]);
   });
 
   test("eslint fix throws on eslint spawn error when it is the first step", () => {
@@ -329,18 +349,15 @@ describe("fix", () => {
   });
 
   test("eslint fix throws on prettier spawn error", () => {
-    let callCount = 0;
     const mockSpawn = mock(
-      (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => {
-        callCount += 1;
-        // eslint succeeds
-        if (callCount === 1) {
-          return { status: 0 };
+      (cmd: string, _args: string[], _opts: SpawnSyncOptions) => {
+        if (cmd === "prettier") {
+          return {
+            error: new Error("prettier spawn failed"),
+            status: null,
+          };
         }
-        return {
-          error: new Error("prettier spawn failed"),
-          status: null,
-        };
+        return { status: 0 };
       }
     );
 
@@ -357,18 +374,15 @@ describe("fix", () => {
   });
 
   test("eslint fix throws on stylelint spawn error", () => {
-    let callCount = 0;
     const mockSpawn = mock(
-      (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => {
-        callCount += 1;
-        // prettier and eslint succeed
-        if (callCount <= 2) {
-          return { status: 0 };
+      (cmd: string, _args: string[], _opts: SpawnSyncOptions) => {
+        if (cmd === "stylelint") {
+          return {
+            error: new Error("stylelint spawn failed"),
+            status: null,
+          };
         }
-        return {
-          error: new Error("stylelint spawn failed"),
-          status: null,
-        };
+        return { status: 0 };
       }
     );
 
@@ -427,7 +441,7 @@ describe("fix", () => {
     expect(oxlintCall[1]).toContain("src/index.ts");
   });
 
-  test("oxlint fix throws on spawn error", () => {
+  test("oxlint fix throws on oxlint spawn error when it is the first step", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
         error: new Error("oxlint spawn failed"),
@@ -445,6 +459,30 @@ describe("fix", () => {
     expect(() => fix([])).toThrow("Failed to run Oxlint: oxlint spawn failed");
   });
 
+  test("oxlint fix throws on oxfmt spawn error", () => {
+    const mockSpawn = mock(
+      (cmd: string, _args: string[], _opts: SpawnSyncOptions) => {
+        if (cmd === "oxfmt") {
+          return {
+            error: new Error("oxfmt spawn failed"),
+            status: null,
+          };
+        }
+        return { status: 0 };
+      }
+    );
+
+    mock.module("../src/spawn-sync", () => ({
+      spawnSync: mockSpawn,
+    }));
+    mock.module("../src/utils", () => ({
+      detectLinter: mock(() => "oxlint"),
+    }));
+
+    expect(() => fix([])).toThrow("Failed to run oxfmt: oxfmt spawn failed");
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+  });
+
   test("oxlint fix throws LinterExitError on failure", () => {
     const mockSpawn = mock(
       (_cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
@@ -460,6 +498,27 @@ describe("fix", () => {
     }));
 
     expect(() => fix([])).toThrow("Oxlint exited with code 1");
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+  });
+
+  test("oxlint fix still runs oxfmt when oxlint exits non-zero", () => {
+    const mockSpawn = mock(
+      (cmd: string, _args: string[], _opts: SpawnSyncOptions) => ({
+        status: cmd === "oxlint" ? 1 : 0,
+      })
+    );
+    mock.module("../src/spawn-sync", () => ({
+      spawnSync: mockSpawn,
+    }));
+    mock.module("../src/utils", () => ({
+      detectLinter: mock(() => "oxlint"),
+    }));
+
+    expect(() => fix([])).toThrow("Oxlint exited with code 1");
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    const [oxlintCall, oxfmtCall] = mockSpawn.mock.calls;
+    expect(oxlintCall[0]).toBe("oxlint");
+    expect(oxfmtCall[0]).toBe("oxfmt");
   });
 
   test("passes through --type-aware flag to oxlint", () => {
@@ -605,7 +664,7 @@ describe("fix", () => {
 
     expect(() => fix([])).toThrow("Prettier exited with code 1");
     expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const [eslintCall, , stylelintCall] = mockSpawn.mock.calls;
+    const [eslintCall, stylelintCall] = mockSpawn.mock.calls;
     expect(eslintCall[0]).toBe("eslint");
     expect(stylelintCall[0]).toBe("stylelint");
   });
@@ -728,11 +787,11 @@ describe("fix with an agent", () => {
     expect(agentCall[1]).toContain("eslint(no-eval)");
     expect(agentCall[1]).toContain("eval can be harmful.");
 
-    // Version check, autofix pass (oxfmt + oxlint), verify pass (oxfmt + oxlint).
+    // Version check, autofix pass (oxlint + oxfmt), verify pass (oxlint + oxfmt).
     const commands = mockSpawn.mock.calls.map((call) => call[0]);
-    expect(commands).toEqual(["claude", "oxfmt", "oxlint", "oxfmt", "oxlint"]);
+    expect(commands).toEqual(["claude", "oxlint", "oxfmt", "oxlint", "oxfmt"]);
 
-    const verifyCall = mockSpawn.mock.calls.at(4);
+    const verifyCall = mockSpawn.mock.calls.at(3);
     expect(verifyCall?.[1]).toContain("src/bad.ts");
   });
 

--- a/packages/cli/__tests__/fix.test.ts
+++ b/packages/cli/__tests__/fix.test.ts
@@ -736,15 +736,17 @@ const mockAgentEnvironment = ({
   agentOk?: boolean;
   oxlintOutputs: string[];
 }) => {
-  let oxlintCalls = 0;
-  const mockSpawn = mock((cmd: string, _args: string[]) => {
+  let collectCalls = 0;
+  const mockSpawn = mock((cmd: string, args: string[]) => {
     if (cmd === "claude" || cmd === "codex") {
       return { status: 0, stdout: "2.0.0" };
     }
-    if (cmd === "oxlint") {
+    // Each pass runs oxlint twice: a fix pass whose output is discarded and
+    // a report-only pass whose JSON feeds the agent. Outputs map to the latter.
+    if (cmd === "oxlint" && args.includes("-f")) {
       const stdout =
-        oxlintOutputs[Math.min(oxlintCalls, oxlintOutputs.length - 1)];
-      oxlintCalls += 1;
+        oxlintOutputs[Math.min(collectCalls, oxlintOutputs.length - 1)];
+      collectCalls += 1;
       return { status: 0, stdout };
     }
     return { status: 0, stdout: "" };
@@ -787,12 +789,23 @@ describe("fix with an agent", () => {
     expect(agentCall[1]).toContain("eslint(no-eval)");
     expect(agentCall[1]).toContain("eval can be harmful.");
 
-    // Version check, autofix pass (oxlint + oxfmt), verify pass (oxlint + oxfmt).
+    // Version check, then autofix and verify passes of
+    // oxlint --fix, oxfmt --write, and a report-only oxlint.
     const commands = mockSpawn.mock.calls.map((call) => call[0]);
-    expect(commands).toEqual(["claude", "oxlint", "oxfmt", "oxlint", "oxfmt"]);
+    expect(commands).toEqual([
+      "claude",
+      "oxlint",
+      "oxfmt",
+      "oxlint",
+      "oxlint",
+      "oxfmt",
+      "oxlint",
+    ]);
 
-    const verifyCall = mockSpawn.mock.calls.at(3);
-    expect(verifyCall?.[1]).toContain("src/bad.ts");
+    const verifyCalls = mockSpawn.mock.calls.slice(4);
+    for (const call of verifyCalls) {
+      expect(call[1]).toContain("src/bad.ts");
+    }
   });
 
   test("throws a LinterExitError when issues remain after the agent run", async () => {
@@ -853,11 +866,13 @@ describe("fix with an agent", () => {
 
     await fix([], ["--unsafe"], { agent: "claude" });
 
-    const oxlintCall = mockSpawn.mock.calls.find(
+    const [fixCall, collectCall] = mockSpawn.mock.calls.filter(
       (call) => call[0] === "oxlint"
     );
-    expect(oxlintCall?.[1]).toContain("--fix-dangerously");
-    expect(oxlintCall?.[1]).not.toContain("--unsafe");
+    expect(fixCall?.[1]).toContain("--fix-dangerously");
+    expect(fixCall?.[1]).not.toContain("--unsafe");
+    expect(collectCall?.[1]).not.toContain("--fix-dangerously");
+    expect(collectCall?.[1]).not.toContain("--unsafe");
   });
 
   test("throws a setup error when the agent CLI is not installed", async () => {

--- a/packages/cli/config/eslint/core/rules/unicorn.mjs
+++ b/packages/cli/config/eslint/core/rules/unicorn.mjs
@@ -40,6 +40,10 @@ const overrideRules = {
   // documentation-comment style that the formatter preserves.
   "unicorn/no-asterisk-prefix-in-documentation-comments": "off",
   "unicorn/no-keyword-prefix": "off",
+  // Its fixer wraps the inner ternary in parentheses that Prettier strips,
+  // so the two fight inside `eslint --fix`. eslint-config-prettier turns it
+  // off for the same reason; the core `no-nested-ternary` still reports.
+  "unicorn/no-nested-ternary": "off",
   "unicorn/no-null": "off",
   "unicorn/no-process-exit": "off",
   "unicorn/prefer-global-this": "off",

--- a/packages/cli/config/oxlint/core/index.mjs
+++ b/packages/cli/config/oxlint/core/index.mjs
@@ -500,7 +500,10 @@ export default defineConfig({
     "unicorn/no-magic-array-flat-depth": "error",
     "unicorn/no-negated-condition": "error",
     "unicorn/no-negation-in-equality-check": "error",
-    "unicorn/no-nested-ternary": "error",
+    // Its fixer wraps the inner ternary in parentheses that oxfmt strips, so
+    // every `fix` run ping-pongs. eslint-config-prettier disables it for the
+    // same reason; the core `no-nested-ternary` still reports the construct.
+    "unicorn/no-nested-ternary": "off",
     "unicorn/no-new-array": "error",
     "unicorn/no-new-buffer": "error",
     "unicorn/no-null": "off",

--- a/packages/cli/src/agent-fix/linters.ts
+++ b/packages/cli/src/agent-fix/linters.ts
@@ -105,24 +105,32 @@ const parseOxlintDiagnostics = (stdout: string): Diagnostic[] => {
 // Lint fixes first, then the formatter, matching the plain `fix` path: a
 // fixer can insert unformatted code and oxfmt is not a diagnostic source, so
 // a formatter-first pass would report "no issues" on a file that still fails
-// `oxfmt --check`.
+// `oxfmt --check`. The diagnostics handed to the agent come from a final
+// report-only pass so their line numbers reflect the formatted file.
 const runOxlintPass = (
   files: string[],
   passthrough: string[]
 ): Diagnostic[] => {
   const hasUnsafe = passthrough.includes("--unsafe");
   const filteredPassthrough = passthrough.filter((arg) => arg !== "--unsafe");
+  const targets = toTargets(files, ".");
+
+  runPiped("oxlint", [
+    hasUnsafe ? "--fix-dangerously" : "--fix",
+    ...filteredPassthrough,
+    ...targets,
+  ]);
+
+  runPiped("oxfmt", ["--write", ...targets]);
+
   // The JSON reporter goes after the passthrough so a user-supplied format
   // flag can't override it and break the parser.
   const stdout = runPiped("oxlint", [
-    hasUnsafe ? "--fix-dangerously" : "--fix",
     ...filteredPassthrough,
     "-f",
     "json",
-    ...toTargets(files, "."),
+    ...targets,
   ]);
-
-  runPiped("oxfmt", ["--write", ...toTargets(files, ".")]);
 
   return parseOxlintDiagnostics(stdout);
 };
@@ -253,21 +261,17 @@ const parseEslintDiagnostics = (stdout: string): Diagnostic[] => {
 /**
  * Stylelint and Prettier run as plain autofix steps — their issues are not
  * handed to the agent in v1. The order matches the plain fix flow: ESLint,
- * then Stylelint, then Prettier, so every fixer's output gets formatted.
+ * then Stylelint, then Prettier, so every fixer's output gets formatted. A
+ * final report-only ESLint pass collects the diagnostics so their line
+ * numbers reflect the formatted file.
  */
 const runEslintPass = (
   files: string[],
   passthrough: string[]
 ): Diagnostic[] => {
-  // The JSON reporter goes after the passthrough so a user-supplied format
-  // flag can't override it and break the parser.
-  const stdout = runPiped("eslint", [
-    "--fix",
-    ...passthrough,
-    "-f",
-    "json",
-    ...toTargets(files, "."),
-  ]);
+  const targets = toTargets(files, ".");
+
+  runPiped("eslint", ["--fix", ...passthrough, ...targets]);
 
   const stylelintTargets = toStylelintTargets(files);
 
@@ -279,7 +283,11 @@ const runEslintPass = (
     ]);
   }
 
-  runPiped("prettier", ["--write", ...toTargets(files, ".")]);
+  runPiped("prettier", ["--write", ...targets]);
+
+  // The JSON reporter goes after the passthrough so a user-supplied format
+  // flag can't override it and break the parser.
+  const stdout = runPiped("eslint", [...passthrough, "-f", "json", ...targets]);
 
   return parseEslintDiagnostics(stdout);
 };

--- a/packages/cli/src/agent-fix/linters.ts
+++ b/packages/cli/src/agent-fix/linters.ts
@@ -102,12 +102,14 @@ const parseOxlintDiagnostics = (stdout: string): Diagnostic[] => {
   return diagnostics;
 };
 
+// Lint fixes first, then the formatter, matching the plain `fix` path: a
+// fixer can insert unformatted code and oxfmt is not a diagnostic source, so
+// a formatter-first pass would report "no issues" on a file that still fails
+// `oxfmt --check`.
 const runOxlintPass = (
   files: string[],
   passthrough: string[]
 ): Diagnostic[] => {
-  runPiped("oxfmt", ["--write", ...toTargets(files, ".")]);
-
   const hasUnsafe = passthrough.includes("--unsafe");
   const filteredPassthrough = passthrough.filter((arg) => arg !== "--unsafe");
   // The JSON reporter goes after the passthrough so a user-supplied format
@@ -119,6 +121,8 @@ const runOxlintPass = (
     "json",
     ...toTargets(files, "."),
   ]);
+
+  runPiped("oxfmt", ["--write", ...toTargets(files, ".")]);
 
   return parseOxlintDiagnostics(stdout);
 };
@@ -247,15 +251,14 @@ const parseEslintDiagnostics = (stdout: string): Diagnostic[] => {
 };
 
 /**
- * Prettier and Stylelint run as plain autofix steps — their issues are not
- * handed to the agent in v1, matching the ESLint-centric plain fix flow.
+ * Stylelint and Prettier run as plain autofix steps — their issues are not
+ * handed to the agent in v1. The order matches the plain fix flow: ESLint,
+ * then Stylelint, then Prettier, so every fixer's output gets formatted.
  */
 const runEslintPass = (
   files: string[],
   passthrough: string[]
 ): Diagnostic[] => {
-  runPiped("prettier", ["--write", ...toTargets(files, ".")]);
-
   // The JSON reporter goes after the passthrough so a user-supplied format
   // flag can't override it and break the parser.
   const stdout = runPiped("eslint", [
@@ -266,24 +269,23 @@ const runEslintPass = (
     ...toTargets(files, "."),
   ]);
 
+  const stylelintTargets = toStylelintTargets(files);
+
+  if (stylelintTargets.length > 0) {
+    runPiped("stylelint", [
+      "--fix",
+      "--allow-empty-input",
+      ...stylelintTargets,
+    ]);
+  }
+
+  runPiped("prettier", ["--write", ...toTargets(files, ".")]);
+
   return parseEslintDiagnostics(stdout);
 };
 
 const eslintAdapter: LinterAdapter = {
-  fixAndCollect: (files, passthrough) => {
-    const diagnostics = runEslintPass(files, passthrough);
-    const stylelintTargets = toStylelintTargets(files);
-
-    if (stylelintTargets.length > 0) {
-      runPiped("stylelint", [
-        "--fix",
-        "--allow-empty-input",
-        ...stylelintTargets,
-      ]);
-    }
-
-    return diagnostics;
-  },
+  fixAndCollect: runEslintPass,
   name: "ESLint",
   verify: (file, passthrough) => runEslintPass([file], passthrough),
 };

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -131,13 +131,14 @@ export const fix = (
 
   switch (linter) {
     // Lint fixes first, then the formatter: a fixer can insert unformatted
-    // code (curly braces, split imports), and only a later format pass makes
-    // one `fix` run idempotent.
+    // code (curly braces, split imports, requoted font names), and only a
+    // later format pass leaves the file in the formatter's shape. The agent
+    // adapters in agent-fix/linters.ts follow the same order.
     case "eslint": {
       runSteps([
         () => runEslintFix(normalizedFiles, passthrough),
-        () => runPrettierFix(normalizedFiles, []),
         () => runStylelintFix(normalizedFiles, []),
+        () => runPrettierFix(normalizedFiles, []),
       ]);
       break;
     }

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -130,18 +130,21 @@ export const fix = (
   }
 
   switch (linter) {
+    // Lint fixes first, then the formatter: a fixer can insert unformatted
+    // code (curly braces, split imports), and only a later format pass makes
+    // one `fix` run idempotent.
     case "eslint": {
       runSteps([
-        () => runPrettierFix(normalizedFiles, []),
         () => runEslintFix(normalizedFiles, passthrough),
+        () => runPrettierFix(normalizedFiles, []),
         () => runStylelintFix(normalizedFiles, []),
       ]);
       break;
     }
     case "oxlint": {
       runSteps([
-        () => runOxfmtFix(normalizedFiles, []),
         () => runOxlintFix(normalizedFiles, passthrough),
+        () => runOxfmtFix(normalizedFiles, []),
       ]);
       break;
     }


### PR DESCRIPTION
## Summary

`ultracite fix` runs the formatter before the linter's fixes: `oxfmt --write` before `oxlint --fix`, and `prettier --write` before `eslint --fix`. A fixer can insert code that is not in the formatter's shape, for example the braces `curly` adds:

```ts
// input
if (a) return 1;
// after `ultracite fix` on 7.10.7
if (a) {return 1;}
// after a second `ultracite fix`
if (a) {
  return 1;
}
```

The same happens with the imports `import/consistent-type-specifier-style` splits and with `switch-case-braces`. So one `fix` is not idempotent, and a lint-staged setup commits half-formatted code. This PR swaps the order so the linter runs first and the formatter second. Stylelint stays last on the ESLint path: it only touches style files, which neither ESLint nor Prettier rewrite.

## Changes

- `packages/cli/src/commands/fix.ts`: `runSteps([oxlint, oxfmt])` and `runSteps([eslint, prettier, stylelint])`.
- `packages/cli/__tests__/fix.test.ts`: order assertions and the spawn-failure tests follow the new order.
- `.changeset/lint-before-format.md`: patch.

## How I found it

Adopting ultracite in a ~35k-file monorepo, `pnpm fix` left every `curly` fix on one line until the next run. Verified against the shipped bundle (`ye([vs, Cs])` in `dist/index.js`, where `vs` is `oxfmt --write`). We are running a trailing `oxfmt --write` in lint-staged as the workaround.

## Test plan

- [x] `bun test` in `packages/cli`: 536 pass, 0 fail
- [x] `bun ./packages/cli/src/index.ts check` on the repo
- [x] `turbo build` + `turbo types`
- [ ] maintainers: is there a reason the formatter was first that I am missing (e.g. an ESLint rule whose fix depends on Prettier's output)? I could not find one in the history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the fix command to run linters before formatters, ensuring automatic fixes are formatted in the same run.
  * Applied the same ordering to agent-assisted fix modes.
  * Improved error and diagnostic reporting so results reflect the final formatted files.
  * Made fix results consistent for changes such as added braces, adjusted type-specifier imports, and font-name quoting.
  * Disabled conflicting nested-ternary fixer rules while retaining reporting through the core lint rule, preventing repeated fix-and-format changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->